### PR TITLE
This pull request fix bugs that can not set ntp_servers as blank list

### DIFF
--- a/ecl/network/v2/subnets/requests.go
+++ b/ecl/network/v2/subnets/requests.go
@@ -160,7 +160,7 @@ type UpdateOpts struct {
 	Description *string `json:"description,omitempty"`
 
 	// NTPServers are List of ntp servers.
-	NTPServers []string `json:"ntp_servers,omitempty"`
+	NTPServers *[]string `json:"ntp_servers,omitempty"`
 
 	// Tags are tags
 	Tags *map[string]string `json:"tags,omitempty"`

--- a/ecl/network/v2/subnets/testing/request_test.go
+++ b/ecl/network/v2/subnets/testing/request_test.go
@@ -143,7 +143,7 @@ func TestUpdateSubnet(t *testing.T) {
 		GatewayIP:      &gatewayIP,
 		HostRoutes:     &hostRoutes,
 		Name:           &name,
-		NTPServers:     ntpServers,
+		NTPServers:     &ntpServers,
 		Tags:           &tags,
 	}
 


### PR DESCRIPTION
According to other same kind of parameters,
this pull request change parameter type from
list of string to its pointer.

Unittest is fixed as well.

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/nttcom/eclcloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

