### PR TITLE
Add VSRX support

### DIFF
--- a/ecl/client.go
+++ b/ecl/client.go
@@ -294,6 +294,13 @@ func NewImageServiceV2(client *eclcloud.ProviderClient, eo eclcloud.EndpointOpts
 	return sc, err
 }
 
+// NewVNAV1 creates a ServiceClient that may be used with the v1 virtual network appliance management package.
+func NewVNAV1(client *eclcloud.ProviderClient, eo eclcloud.EndpointOpts) (*eclcloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "virtual-network-appliance")
+	sc.ResourceBase = sc.Endpoint + "v1.0/"
+	return sc, err
+}
+
 // NewLoadBalancerV2 creates a ServiceClient that may be used to access the v2
 // load balancer service.
 func NewLoadBalancerV2(client *eclcloud.ProviderClient, eo eclcloud.EndpointOpts) (*eclcloud.ServiceClient, error) {

--- a/ecl/vna/v1/appliances/doc.go
+++ b/ecl/vna/v1/appliances/doc.go
@@ -1,0 +1,57 @@
+/*
+Package appliances contains functionality for working with
+ECL Commnon Function Gateway resources.
+
+Example to List VirtualNetworkAppliances
+
+	listOpts := virtual_network_appliances.ListOpts{
+		TenantID: "a99e9b4e620e4db09a2dfb6e42a01e66",
+	}
+
+	allPages, err := virtual_network_appliances.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allVirtualNetworkAppliances, err := virtual_network_appliances.ExtractVirtualNetworkAppliances(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, virtual_network_appliances := range allVirtualNetworkAppliances {
+		fmt.Printf("%+v", virtual_network_appliances)
+	}
+
+Example to Create a virtual_network_appliances
+
+	createOpts := virtual_network_appliances.CreateOpts{
+		Name:         "network_1",
+	}
+
+	virtual_network_appliances, err := virtual_network_appliances.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a virtual_network_appliances
+
+	virtualNetworkApplianceID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
+
+	updateOpts := virtual_network_appliances.UpdateOpts{
+		Name: "new_name",
+	}
+
+	virtual_network_appliances, err := virtual_network_appliances.Update(networkClient, virtualNetworkApplianceID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a virtual_network_appliances
+
+	virtualNetworkApplianceID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
+	err := virtual_network_appliances.Delete(networkClient, virtualNetworkApplianceID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package appliances

--- a/ecl/vna/v1/appliances/requests.go
+++ b/ecl/vna/v1/appliances/requests.go
@@ -1,0 +1,255 @@
+package appliances
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToVirtualNetworkApplianceListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the virtual network appliance attributes you want to see returned.
+type ListOpts struct {
+	Name                          string `q:"name"`
+	ID                            string `q:"id"`
+	ApplianceType                 string `q:"appliance_type`
+	Description                   string `q:"description"`
+	AvailabilityZone              string `q:"availability_zone"`
+	OSMonitoringStatus            string `q:"os_monitoring_status"`
+	OSLoginStatus                 string `q:"os_login_status"`
+	VMStatus                      string `q:"vm_status"`
+	OperationStatus               string `q:"operation_status"`
+	VirtualNetworkAppliancePlanID string `q:"virtual_network_appliance_plan_id"`
+	TenantID                      string `q:"tenant_id"`
+}
+
+// ToVirtualNetworkApplianceListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVirtualNetworkApplianceListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// virtual network appliances.
+// It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *eclcloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToVirtualNetworkApplianceListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return AppliancePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific virtual network appliance based on its unique ID.
+func Get(c *eclcloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToApplianceCreateMap() (map[string]interface{}, error)
+}
+
+/*
+Parameters for Create
+*/
+
+type CreateOptsFixedIP struct {
+	IPAddress string `json:"ip_address" required:"true"`
+}
+
+type CreateOptsInterface struct {
+	Name        string               `json:"name,omitempty"`
+	Description string               `json:"description,omitempty"`
+	NetworkID   string               `json:"network_id" required:"true"`
+	Tags        map[string]string    `json:"tags,omitempty"`
+	FixedIPs    [1]CreateOptsFixedIP `json:"fixed_ips,required"`
+}
+
+type CreateOptsInterfaces struct {
+	Interface1 CreateOptsInterface `json:"interface_1" required:"true"`
+}
+
+// CreateOpts represents options used to create a virtual network appliance.
+type CreateOpts struct {
+	Name                          string               `json:"name,omitempty"`
+	Description                   string               `json:"description,omitempty"`
+	DefaultGateway                string               `json:"default_gateway,omitempty"`
+	AvailabilityZone              string               `json:"availability_zone,omitempty"`
+	VirtualNetworkAppliancePlanID string               `json:"virtual_network_appliance_plan_id" required:"true"`
+	TenantID                      string               `json:"tenant_id,omitempty"`
+	Tags                          map[string]string    `json:"tags,omitempty"`
+	Interfaces                    CreateOptsInterfaces `json:"interfaces,omitempty"`
+}
+
+// ToApplianceCreateMap builds a request body from CreateOpts.
+// func (opts CreateOpts) ToApplianceCreateMap() (map[string]interface{}, error) {
+func (opts CreateOpts) ToApplianceCreateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "virtual_network_appliance")
+}
+
+// Create accepts a CreateOpts struct and creates a new virtual network appliance
+// using the values provided.
+// This operation does not actually require a request body, i.e. the
+// CreateOpts struct argument can be empty.
+//
+// The tenant ID that is contained in the URI is the tenant that creates the
+// virtual network appliance.
+// An admin user, however, has the option of specifying another tenant
+// ID in the CreateOpts struct.
+func Create(c *eclcloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToApplianceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToApplianceUpdateMap() (map[string]interface{}, error)
+}
+
+/*
+Update for FixedIP (includes network_id)
+*/
+
+type UpdateFixedIPAddressInfo struct {
+	IPAddress string `json:"ip_address" required:"true"`
+}
+
+type UpdateFixedIPInterface struct {
+	NetworkID *string                     `json:"network_id,omitempty"`
+	FixedIPs  *[]UpdateFixedIPAddressInfo `json:"fixed_ips,omitempty"`
+}
+
+type UpdateFixedIPInterfaces struct {
+	Interface1 *UpdateFixedIPInterface `json:"interface_1,omitempty"`
+	Interface2 *UpdateFixedIPInterface `json:"interface_2,omitempty"`
+	Interface3 *UpdateFixedIPInterface `json:"interface_3,omitempty"`
+	Interface4 *UpdateFixedIPInterface `json:"interface_4,omitempty"`
+	Interface5 *UpdateFixedIPInterface `json:"interface_5,omitempty"`
+	Interface6 *UpdateFixedIPInterface `json:"interface_6,omitempty"`
+	Interface7 *UpdateFixedIPInterface `json:"interface_7,omitempty"`
+	Interface8 *UpdateFixedIPInterface `json:"interface_8,omitempty"`
+}
+
+type UpdateFixedIPOpts struct {
+	Interfaces UpdateFixedIPInterfaces `json:"interfaces,omitempty"`
+}
+
+func (opts UpdateFixedIPOpts) ToApplianceUpdateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "virtual_network_appliance")
+}
+
+/*
+Update for Metadata
+*/
+type UpdateMetadataInterface struct {
+	Name        *string            `json:"name,omitempty"`
+	Description *string            `json:"description,omitempty"`
+	Tags        *map[string]string `json:"tags,omitempty"`
+}
+
+type UpdateMetadataInterfaces struct {
+	Interface1 *UpdateMetadataInterface `json:"interface_1,omitempty"`
+	Interface2 *UpdateMetadataInterface `json:"interface_2,omitempty"`
+	Interface3 *UpdateMetadataInterface `json:"interface_3,omitempty"`
+	Interface4 *UpdateMetadataInterface `json:"interface_4,omitempty"`
+	Interface5 *UpdateMetadataInterface `json:"interface_5,omitempty"`
+	Interface6 *UpdateMetadataInterface `json:"interface_6,omitempty"`
+	Interface7 *UpdateMetadataInterface `json:"interface_7,omitempty"`
+	Interface8 *UpdateMetadataInterface `json:"interface_8,omitempty"`
+}
+
+type UpdateMetadataOpts struct {
+	Name        *string                  `json:"name,omitempty"`
+	Description *string                  `json:"description,omitempty"`
+	Tags        *map[string]string       `json:"tags,omitempty"`
+	Interfaces  UpdateMetadataInterfaces `json:"interfaces,omitempty"`
+}
+
+// ToApplianceUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateMetadataOpts) ToApplianceUpdateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "virtual_network_appliance")
+}
+
+/*
+Update Common
+*/
+
+// Update accepts a UpdateOpts struct and updates an existing virtual network appliance
+// using the values provided. For more information, see the Create function.
+func Update(c *eclcloud.ServiceClient, virtualNetworkApplianceID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToApplianceUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Patch(updateURL(c, virtualNetworkApplianceID), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete accepts a unique ID and deletes the virtual network appliance associated with it.
+func Delete(c *eclcloud.ServiceClient, virtualNetworkApplianceID string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, virtualNetworkApplianceID), nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a virtual network appliance's
+// ID, given its name.
+func IDFromName(client *eclcloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractAppliances(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", eclcloud.ErrResourceNotFound{Name: name, ResourceType: "virtual_network_appliance"}
+	case 1:
+		return id, nil
+	default:
+		return "", eclcloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "virtual_network_appliance"}
+	}
+}

--- a/ecl/vna/v1/appliances/requests.go
+++ b/ecl/vna/v1/appliances/requests.go
@@ -77,7 +77,7 @@ type CreateOptsInterface struct {
 	Description string               `json:"description,omitempty"`
 	NetworkID   string               `json:"network_id" required:"true"`
 	Tags        map[string]string    `json:"tags,omitempty"`
-	FixedIPs    [1]CreateOptsFixedIP `json:"fixed_ips,required"`
+	FixedIPs    [1]CreateOptsFixedIP `json:"fixed_ips" required:"true"`
 }
 
 type CreateOptsInterfaces struct {
@@ -127,6 +127,40 @@ func Create(c *eclcloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) 
 // Update request.
 type UpdateOptsBuilder interface {
 	ToApplianceUpdateMap() (map[string]interface{}, error)
+}
+
+/*
+Update for Allowed Address Pairs
+*/
+
+type UpdateAllowedAddressPairAddressInfo struct {
+	IPAddress  string  `json:"ip_address" required:"true"`
+	MACAddress string  `json:"mac_address" required:"true"`
+	Type       *string `json:"type" required:"true"`
+	VRID       int     `json:"vrid" required:"true"`
+}
+
+type UpdateAllowedAddressPairInterface struct {
+	AllowedAddressPairs *[]UpdateAllowedAddressPairAddressInfo `json:"allowed_address_pairs,omitempty"`
+}
+
+type UpdateAllowedAddressPairInterfaces struct {
+	Interface1 *UpdateAllowedAddressPairInterface `json:"interface_1,omitempty"`
+	Interface2 *UpdateAllowedAddressPairInterface `json:"interface_2,omitempty"`
+	Interface3 *UpdateAllowedAddressPairInterface `json:"interface_3,omitempty"`
+	Interface4 *UpdateAllowedAddressPairInterface `json:"interface_4,omitempty"`
+	Interface5 *UpdateAllowedAddressPairInterface `json:"interface_5,omitempty"`
+	Interface6 *UpdateAllowedAddressPairInterface `json:"interface_6,omitempty"`
+	Interface7 *UpdateAllowedAddressPairInterface `json:"interface_7,omitempty"`
+	Interface8 *UpdateAllowedAddressPairInterface `json:"interface_8,omitempty"`
+}
+
+type UpdateAllowedAddressPairOpts struct {
+	Interfaces UpdateAllowedAddressPairInterfaces `json:"interfaces,omitempty"`
+}
+
+func (opts UpdateAllowedAddressPairOpts) ToApplianceUpdateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "virtual_network_appliance")
 }
 
 /*

--- a/ecl/vna/v1/appliances/requests.go
+++ b/ecl/vna/v1/appliances/requests.go
@@ -134,10 +134,10 @@ Update for Allowed Address Pairs
 */
 
 type UpdateAllowedAddressPairAddressInfo struct {
-	IPAddress  string  `json:"ip_address" required:"true"`
-	MACAddress string  `json:"mac_address" required:"true"`
-	Type       *string `json:"type" required:"true"`
-	VRID       int     `json:"vrid" required:"true"`
+	IPAddress  string       `json:"ip_address" required:"true"`
+	MACAddress *string      `json:"mac_address" required:"true"`
+	Type       *string      `json:"type" required:"true"`
+	VRID       *interface{} `json:"vrid" required:"true"`
 }
 
 type UpdateAllowedAddressPairInterface struct {
@@ -145,18 +145,18 @@ type UpdateAllowedAddressPairInterface struct {
 }
 
 type UpdateAllowedAddressPairInterfaces struct {
-	Interface1 *UpdateAllowedAddressPairInterface `json:"interface_1,omitempty"`
-	Interface2 *UpdateAllowedAddressPairInterface `json:"interface_2,omitempty"`
-	Interface3 *UpdateAllowedAddressPairInterface `json:"interface_3,omitempty"`
-	Interface4 *UpdateAllowedAddressPairInterface `json:"interface_4,omitempty"`
-	Interface5 *UpdateAllowedAddressPairInterface `json:"interface_5,omitempty"`
-	Interface6 *UpdateAllowedAddressPairInterface `json:"interface_6,omitempty"`
-	Interface7 *UpdateAllowedAddressPairInterface `json:"interface_7,omitempty"`
-	Interface8 *UpdateAllowedAddressPairInterface `json:"interface_8,omitempty"`
+	Interface1 interface{} `json:"interface_1,omitempty"`
+	Interface2 interface{} `json:"interface_2,omitempty"`
+	Interface3 interface{} `json:"interface_3,omitempty"`
+	Interface4 interface{} `json:"interface_4,omitempty"`
+	Interface5 interface{} `json:"interface_5,omitempty"`
+	Interface6 interface{} `json:"interface_6,omitempty"`
+	Interface7 interface{} `json:"interface_7,omitempty"`
+	Interface8 interface{} `json:"interface_8,omitempty"`
 }
 
 type UpdateAllowedAddressPairOpts struct {
-	Interfaces UpdateAllowedAddressPairInterfaces `json:"interfaces,omitempty"`
+	Interfaces interface{} `json:"interfaces,omitempty"`
 }
 
 func (opts UpdateAllowedAddressPairOpts) ToApplianceUpdateMap() (map[string]interface{}, error) {
@@ -177,18 +177,18 @@ type UpdateFixedIPInterface struct {
 }
 
 type UpdateFixedIPInterfaces struct {
-	Interface1 *UpdateFixedIPInterface `json:"interface_1,omitempty"`
-	Interface2 *UpdateFixedIPInterface `json:"interface_2,omitempty"`
-	Interface3 *UpdateFixedIPInterface `json:"interface_3,omitempty"`
-	Interface4 *UpdateFixedIPInterface `json:"interface_4,omitempty"`
-	Interface5 *UpdateFixedIPInterface `json:"interface_5,omitempty"`
-	Interface6 *UpdateFixedIPInterface `json:"interface_6,omitempty"`
-	Interface7 *UpdateFixedIPInterface `json:"interface_7,omitempty"`
-	Interface8 *UpdateFixedIPInterface `json:"interface_8,omitempty"`
+	Interface1 interface{} `json:"interface_1,omitempty"`
+	Interface2 interface{} `json:"interface_2,omitempty"`
+	Interface3 interface{} `json:"interface_3,omitempty"`
+	Interface4 interface{} `json:"interface_4,omitempty"`
+	Interface5 interface{} `json:"interface_5,omitempty"`
+	Interface6 interface{} `json:"interface_6,omitempty"`
+	Interface7 interface{} `json:"interface_7,omitempty"`
+	Interface8 interface{} `json:"interface_8,omitempty"`
 }
 
 type UpdateFixedIPOpts struct {
-	Interfaces UpdateFixedIPInterfaces `json:"interfaces,omitempty"`
+	Interfaces interface{} `json:"interfaces,omitempty"`
 }
 
 func (opts UpdateFixedIPOpts) ToApplianceUpdateMap() (map[string]interface{}, error) {

--- a/ecl/vna/v1/appliances/requests.go
+++ b/ecl/vna/v1/appliances/requests.go
@@ -150,21 +150,21 @@ type UpdateAllowedAddressPairInterface struct {
 // interface list of update options used to
 // update virtual network appliance allowed address pairs.
 type UpdateAllowedAddressPairInterfaces struct {
-	Interface1 interface{} `json:"interface_1,omitempty"`
-	Interface2 interface{} `json:"interface_2,omitempty"`
-	Interface3 interface{} `json:"interface_3,omitempty"`
-	Interface4 interface{} `json:"interface_4,omitempty"`
-	Interface5 interface{} `json:"interface_5,omitempty"`
-	Interface6 interface{} `json:"interface_6,omitempty"`
-	Interface7 interface{} `json:"interface_7,omitempty"`
-	Interface8 interface{} `json:"interface_8,omitempty"`
+	Interface1 *UpdateAllowedAddressPairInterface `json:"interface_1,omitempty"`
+	Interface2 *UpdateAllowedAddressPairInterface `json:"interface_2,omitempty"`
+	Interface3 *UpdateAllowedAddressPairInterface `json:"interface_3,omitempty"`
+	Interface4 *UpdateAllowedAddressPairInterface `json:"interface_4,omitempty"`
+	Interface5 *UpdateAllowedAddressPairInterface `json:"interface_5,omitempty"`
+	Interface6 *UpdateAllowedAddressPairInterface `json:"interface_6,omitempty"`
+	Interface7 *UpdateAllowedAddressPairInterface `json:"interface_7,omitempty"`
+	Interface8 *UpdateAllowedAddressPairInterface `json:"interface_8,omitempty"`
 }
 
 // UpdateAllowedAddressPairOpts represents
 // parent element of interfaces in update options used to
 // update virtual network appliance allowed address pairs.
 type UpdateAllowedAddressPairOpts struct {
-	Interfaces interface{} `json:"interfaces,omitempty"`
+	Interfaces *UpdateAllowedAddressPairInterfaces `json:"interfaces,omitempty"`
 }
 
 // ToApplianceUpdateMap builds a request body from UpdateAllowedAddressPairOpts.
@@ -194,21 +194,21 @@ type UpdateFixedIPInterface struct {
 // interface list of update options used to
 // update virtual network appliance network connection and fixed ips.
 type UpdateFixedIPInterfaces struct {
-	Interface1 interface{} `json:"interface_1,omitempty"`
-	Interface2 interface{} `json:"interface_2,omitempty"`
-	Interface3 interface{} `json:"interface_3,omitempty"`
-	Interface4 interface{} `json:"interface_4,omitempty"`
-	Interface5 interface{} `json:"interface_5,omitempty"`
-	Interface6 interface{} `json:"interface_6,omitempty"`
-	Interface7 interface{} `json:"interface_7,omitempty"`
-	Interface8 interface{} `json:"interface_8,omitempty"`
+	Interface1 *UpdateFixedIPInterface `json:"interface_1,omitempty"`
+	Interface2 *UpdateFixedIPInterface `json:"interface_2,omitempty"`
+	Interface3 *UpdateFixedIPInterface `json:"interface_3,omitempty"`
+	Interface4 *UpdateFixedIPInterface `json:"interface_4,omitempty"`
+	Interface5 *UpdateFixedIPInterface `json:"interface_5,omitempty"`
+	Interface6 *UpdateFixedIPInterface `json:"interface_6,omitempty"`
+	Interface7 *UpdateFixedIPInterface `json:"interface_7,omitempty"`
+	Interface8 *UpdateFixedIPInterface `json:"interface_8,omitempty"`
 }
 
 // UpdateFixedIPOpts represents
 // parent element of interfaces in update options used to
 // update virtual network appliance network connection and fixed ips.
 type UpdateFixedIPOpts struct {
-	Interfaces interface{} `json:"interfaces,omitempty"`
+	Interfaces *UpdateFixedIPInterfaces `json:"interfaces,omitempty"`
 }
 
 // ToApplianceUpdateMap builds a request body from UpdateFixedIPOpts.
@@ -231,14 +231,14 @@ type UpdateMetadataInterface struct {
 // UpdateMetadataInterfaces represents
 // list of interfaces for updating virtual network appliance metadata.
 type UpdateMetadataInterfaces struct {
-	Interface1 interface{} `json:"interface_1,omitempty"`
-	Interface2 interface{} `json:"interface_2,omitempty"`
-	Interface3 interface{} `json:"interface_3,omitempty"`
-	Interface4 interface{} `json:"interface_4,omitempty"`
-	Interface5 interface{} `json:"interface_5,omitempty"`
-	Interface6 interface{} `json:"interface_6,omitempty"`
-	Interface7 interface{} `json:"interface_7,omitempty"`
-	Interface8 interface{} `json:"interface_8,omitempty"`
+	Interface1 *UpdateMetadataInterface `json:"interface_1,omitempty"`
+	Interface2 *UpdateMetadataInterface `json:"interface_2,omitempty"`
+	Interface3 *UpdateMetadataInterface `json:"interface_3,omitempty"`
+	Interface4 *UpdateMetadataInterface `json:"interface_4,omitempty"`
+	Interface5 *UpdateMetadataInterface `json:"interface_5,omitempty"`
+	Interface6 *UpdateMetadataInterface `json:"interface_6,omitempty"`
+	Interface7 *UpdateMetadataInterface `json:"interface_7,omitempty"`
+	Interface8 *UpdateMetadataInterface `json:"interface_8,omitempty"`
 }
 
 // UpdateMetadataOpts represents
@@ -246,10 +246,10 @@ type UpdateMetadataInterfaces struct {
 // pararent element for list of interfaces
 // which are used by virtual network appliance metadata update.
 type UpdateMetadataOpts struct {
-	Name        *string            `json:"name,omitempty"`
-	Description *string            `json:"description,omitempty"`
-	Tags        *map[string]string `json:"tags,omitempty"`
-	Interfaces  interface{}        `json:"interfaces,omitempty"`
+	Name        *string                   `json:"name,omitempty"`
+	Description *string                   `json:"description,omitempty"`
+	Tags        *map[string]string        `json:"tags,omitempty"`
+	Interfaces  *UpdateMetadataInterfaces `json:"interfaces,omitempty"`
 }
 
 // ToApplianceUpdateMap builds a request body from UpdateOpts.

--- a/ecl/vna/v1/appliances/requests.go
+++ b/ecl/vna/v1/appliances/requests.go
@@ -205,21 +205,21 @@ type UpdateMetadataInterface struct {
 }
 
 type UpdateMetadataInterfaces struct {
-	Interface1 *UpdateMetadataInterface `json:"interface_1,omitempty"`
-	Interface2 *UpdateMetadataInterface `json:"interface_2,omitempty"`
-	Interface3 *UpdateMetadataInterface `json:"interface_3,omitempty"`
-	Interface4 *UpdateMetadataInterface `json:"interface_4,omitempty"`
-	Interface5 *UpdateMetadataInterface `json:"interface_5,omitempty"`
-	Interface6 *UpdateMetadataInterface `json:"interface_6,omitempty"`
-	Interface7 *UpdateMetadataInterface `json:"interface_7,omitempty"`
-	Interface8 *UpdateMetadataInterface `json:"interface_8,omitempty"`
+	Interface1 interface{} `json:"interface_1,omitempty"`
+	Interface2 interface{} `json:"interface_2,omitempty"`
+	Interface3 interface{} `json:"interface_3,omitempty"`
+	Interface4 interface{} `json:"interface_4,omitempty"`
+	Interface5 interface{} `json:"interface_5,omitempty"`
+	Interface6 interface{} `json:"interface_6,omitempty"`
+	Interface7 interface{} `json:"interface_7,omitempty"`
+	Interface8 interface{} `json:"interface_8,omitempty"`
 }
 
 type UpdateMetadataOpts struct {
 	Name        *string                  `json:"name,omitempty"`
 	Description *string                  `json:"description,omitempty"`
 	Tags        *map[string]string       `json:"tags,omitempty"`
-	Interfaces  UpdateMetadataInterfaces `json:"interfaces,omitempty"`
+	Interfaces  interface{}              `json:"interfaces,omitempty"`
 }
 
 // ToApplianceUpdateMap builds a request body from UpdateOpts.

--- a/ecl/vna/v1/appliances/requests.go
+++ b/ecl/vna/v1/appliances/requests.go
@@ -68,10 +68,12 @@ type CreateOptsBuilder interface {
 Parameters for Create
 */
 
+// CreateOptsFixedIP represents fixed ip information in virtual network appliance creation.
 type CreateOptsFixedIP struct {
 	IPAddress string `json:"ip_address" required:"true"`
 }
 
+// CreateOptsInterface represents each parameters in virtual network appliance creation.
 type CreateOptsInterface struct {
 	Name        string               `json:"name,omitempty"`
 	Description string               `json:"description,omitempty"`
@@ -80,6 +82,7 @@ type CreateOptsInterface struct {
 	FixedIPs    [1]CreateOptsFixedIP `json:"fixed_ips" required:"true"`
 }
 
+// CreateOptsInterfaces represents 1st interface in virtual network appliance creation.
 type CreateOptsInterfaces struct {
 	Interface1 CreateOptsInterface `json:"interface_1" required:"true"`
 }
@@ -97,7 +100,6 @@ type CreateOpts struct {
 }
 
 // ToApplianceCreateMap builds a request body from CreateOpts.
-// func (opts CreateOpts) ToApplianceCreateMap() (map[string]interface{}, error) {
 func (opts CreateOpts) ToApplianceCreateMap() (map[string]interface{}, error) {
 	return eclcloud.BuildRequestBody(opts, "virtual_network_appliance")
 }
@@ -106,11 +108,6 @@ func (opts CreateOpts) ToApplianceCreateMap() (map[string]interface{}, error) {
 // using the values provided.
 // This operation does not actually require a request body, i.e. the
 // CreateOpts struct argument can be empty.
-//
-// The tenant ID that is contained in the URI is the tenant that creates the
-// virtual network appliance.
-// An admin user, however, has the option of specifying another tenant
-// ID in the CreateOpts struct.
 func Create(c *eclcloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToApplianceCreateMap()
 	if err != nil {
@@ -133,6 +130,8 @@ type UpdateOptsBuilder interface {
 Update for Allowed Address Pairs
 */
 
+// UpdateAllowedAddressPairAddressInfo represents options used to
+// update virtual network appliance allowed address pairs.
 type UpdateAllowedAddressPairAddressInfo struct {
 	IPAddress  string       `json:"ip_address" required:"true"`
 	MACAddress *string      `json:"mac_address" required:"true"`
@@ -140,10 +139,16 @@ type UpdateAllowedAddressPairAddressInfo struct {
 	VRID       *interface{} `json:"vrid" required:"true"`
 }
 
+// UpdateAllowedAddressPairInterface represents
+// allowed address pairs list in update options used to
+// update virtual network appliance allowed address pairs.
 type UpdateAllowedAddressPairInterface struct {
 	AllowedAddressPairs *[]UpdateAllowedAddressPairAddressInfo `json:"allowed_address_pairs,omitempty"`
 }
 
+// UpdateAllowedAddressPairInterfaces represents
+// interface list of update options used to
+// update virtual network appliance allowed address pairs.
 type UpdateAllowedAddressPairInterfaces struct {
 	Interface1 interface{} `json:"interface_1,omitempty"`
 	Interface2 interface{} `json:"interface_2,omitempty"`
@@ -155,10 +160,14 @@ type UpdateAllowedAddressPairInterfaces struct {
 	Interface8 interface{} `json:"interface_8,omitempty"`
 }
 
+// UpdateAllowedAddressPairOpts represents
+// parent element of interfaces in update options used to
+// update virtual network appliance allowed address pairs.
 type UpdateAllowedAddressPairOpts struct {
 	Interfaces interface{} `json:"interfaces,omitempty"`
 }
 
+// ToApplianceUpdateMap builds a request body from UpdateAllowedAddressPairOpts.
 func (opts UpdateAllowedAddressPairOpts) ToApplianceUpdateMap() (map[string]interface{}, error) {
 	return eclcloud.BuildRequestBody(opts, "virtual_network_appliance")
 }
@@ -167,15 +176,23 @@ func (opts UpdateAllowedAddressPairOpts) ToApplianceUpdateMap() (map[string]inte
 Update for FixedIP (includes network_id)
 */
 
+// UpdateFixedIPAddressInfo represents ip address part
+// of virtual network appliance update.
 type UpdateFixedIPAddressInfo struct {
 	IPAddress string `json:"ip_address" required:"true"`
 }
 
+// UpdateFixedIPInterface represents each interface information
+// in updating network connection and fixed ip address
+// of virtual network appliance.
 type UpdateFixedIPInterface struct {
 	NetworkID *string                     `json:"network_id,omitempty"`
 	FixedIPs  *[]UpdateFixedIPAddressInfo `json:"fixed_ips,omitempty"`
 }
 
+// UpdateFixedIPInterfaces represents
+// interface list of update options used to
+// update virtual network appliance network connection and fixed ips.
 type UpdateFixedIPInterfaces struct {
 	Interface1 interface{} `json:"interface_1,omitempty"`
 	Interface2 interface{} `json:"interface_2,omitempty"`
@@ -187,10 +204,14 @@ type UpdateFixedIPInterfaces struct {
 	Interface8 interface{} `json:"interface_8,omitempty"`
 }
 
+// UpdateFixedIPOpts represents
+// parent element of interfaces in update options used to
+// update virtual network appliance network connection and fixed ips.
 type UpdateFixedIPOpts struct {
 	Interfaces interface{} `json:"interfaces,omitempty"`
 }
 
+// ToApplianceUpdateMap builds a request body from UpdateFixedIPOpts.
 func (opts UpdateFixedIPOpts) ToApplianceUpdateMap() (map[string]interface{}, error) {
 	return eclcloud.BuildRequestBody(opts, "virtual_network_appliance")
 }
@@ -198,12 +219,17 @@ func (opts UpdateFixedIPOpts) ToApplianceUpdateMap() (map[string]interface{}, er
 /*
 Update for Metadata
 */
+
+// UpdateMetadataInterface represents options used to
+// update virtual network appliance metadata of interface.
 type UpdateMetadataInterface struct {
 	Name        *string            `json:"name,omitempty"`
 	Description *string            `json:"description,omitempty"`
 	Tags        *map[string]string `json:"tags,omitempty"`
 }
 
+// UpdateMetadataInterfaces represents
+// list of interfaces for updating virtual network appliance metadata.
 type UpdateMetadataInterfaces struct {
 	Interface1 interface{} `json:"interface_1,omitempty"`
 	Interface2 interface{} `json:"interface_2,omitempty"`
@@ -215,11 +241,15 @@ type UpdateMetadataInterfaces struct {
 	Interface8 interface{} `json:"interface_8,omitempty"`
 }
 
+// UpdateMetadataOpts represents
+// metadata of virtual network appliance itself and
+// pararent element for list of interfaces
+// which are used by virtual network appliance metadata update.
 type UpdateMetadataOpts struct {
-	Name        *string                  `json:"name,omitempty"`
-	Description *string                  `json:"description,omitempty"`
-	Tags        *map[string]string       `json:"tags,omitempty"`
-	Interfaces  interface{}              `json:"interfaces,omitempty"`
+	Name        *string            `json:"name,omitempty"`
+	Description *string            `json:"description,omitempty"`
+	Tags        *map[string]string `json:"tags,omitempty"`
+	Interfaces  interface{}        `json:"interfaces,omitempty"`
 }
 
 // ToApplianceUpdateMap builds a request body from UpdateOpts.

--- a/ecl/vna/v1/appliances/requests.go
+++ b/ecl/vna/v1/appliances/requests.go
@@ -96,7 +96,7 @@ type CreateOpts struct {
 	VirtualNetworkAppliancePlanID string               `json:"virtual_network_appliance_plan_id" required:"true"`
 	TenantID                      string               `json:"tenant_id,omitempty"`
 	Tags                          map[string]string    `json:"tags,omitempty"`
-	Interfaces                    CreateOptsInterfaces `json:"interfaces,omitempty"`
+	Interfaces                    CreateOptsInterfaces `json:"interfaces" required:"true"`
 }
 
 // ToApplianceCreateMap builds a request body from CreateOpts.

--- a/ecl/vna/v1/appliances/results.go
+++ b/ecl/vna/v1/appliances/results.go
@@ -52,10 +52,10 @@ type FixedIPInResponse struct {
 }
 
 type AllowedAddressPairInResponse struct {
-	IPAddress  string `json:"ip_address"`
-	MACAddress string `json:"mac_address"`
-	Type       string `json:"type"`
-	VRID       string `json:"vrid"`
+	IPAddress  string      `json:"ip_address"`
+	MACAddress string      `json:"mac_address"`
+	Type       string      `json:"type"`
+	VRID       interface{} `json:"vrid"`
 }
 
 type InterfaceInResponse struct {

--- a/ecl/vna/v1/appliances/results.go
+++ b/ecl/vna/v1/appliances/results.go
@@ -1,0 +1,140 @@
+package appliances
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// Extract is a function that accepts a result
+// and extracts a virtual network appliance resource.
+func (r commonResult) Extract() (*Appliance, error) {
+	var vna Appliance
+	err := r.ExtractInto(&vna)
+	return &vna, err
+}
+
+// Extract interprets any commonResult as a Virtual Network Appliance, if possible.
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "virtual_network_appliance")
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Virtual Network Appliance.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Virtual Network Appliance.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Virtual Network Appliance.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	eclcloud.ErrResult
+}
+
+type FixedIPInResponse struct {
+	IPAddress string `json:"ip_address"`
+	SubnetID  string `json:"subnet_id"`
+}
+
+type AllowedAddressPairInResponse struct {
+	IPAddress  string `json:"ip_address"`
+	MACAddress string `json:"mac_address"`
+	Type       string `json:"type"`
+	VRID       string `json:"vrid"`
+}
+
+type InterfaceInResponse struct {
+	Name                string                         `json:"name"`
+	Description         string                         `json:"description"`
+	NetworkID           string                         `json:"network_id"`
+	Updatable           bool                           `json:"updatable"`
+	Tags                map[string]string              `json:"tags"`
+	FixedIPs            []FixedIPInResponse            `json:"fixed_ips"`
+	AllowedAddressPairs []AllowedAddressPairInResponse `json:"allowed_address_pairs"`
+}
+
+type InterfacesInResponse struct {
+	Interface1 InterfaceInResponse `json:"interface_1"`
+	Interface2 InterfaceInResponse `json:"interface_2"`
+	Interface3 InterfaceInResponse `json:"interface_3"`
+	Interface4 InterfaceInResponse `json:"interface_4"`
+	Interface5 InterfaceInResponse `json:"interface_5"`
+	Interface6 InterfaceInResponse `json:"interface_6"`
+	Interface7 InterfaceInResponse `json:"interface_7"`
+	Interface8 InterfaceInResponse `json:"interface_8"`
+}
+
+// Appliance represents, well, a virtual network appliance.
+type Appliance struct {
+	Name               string               `json:"name"`
+	ID                 string               `json:"id"`
+	ApplianceType      string               `json:"appliance_type"`
+	Description        string               `json:"description"`
+	DefaultGateway     string               `json:"default_gateway"`
+	AvailabilityZone   string               `json:"availability_zone"`
+	OSMonitoringStatus string               `json:"os_monitoring_status"`
+	OSLoginStatus      string               `json:"os_login_status"`
+	VMStatus           string               `json:"vm_status"`
+	OperationStatus    string               `json:"operation_status"`
+	AppliancePlanID    string               `json:"virtual_network_appliance_plan_id"`
+	TenantID           string               `json:"tenant_id"`
+	Tags               map[string]string    `json:"tags"`
+	Interfaces         InterfacesInResponse `json:"interfaces"`
+}
+
+// AppliancePage is the page returned by a pager
+// when traversing over a collection of virtual network appliance.
+type AppliancePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of virtual network appliance
+//  has reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r AppliancePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []eclcloud.Link `json:"appliances_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return eclcloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a AppliancePage struct is empty.
+func (r AppliancePage) IsEmpty() (bool, error) {
+	is, err := ExtractAppliances(r)
+	return len(is) == 0, err
+}
+
+// ExtractAppliances accepts a Page struct,
+// specifically a NetworkPage struct, and extracts the elements
+// into a slice of Virtual Network Appliance structs.
+// In other words, a generic collection is mapped into a relevant slice.
+func ExtractAppliances(r pagination.Page) ([]Appliance, error) {
+	var s []Appliance
+	err := ExtractAppliancesInto(r, &s)
+	return s, err
+}
+
+// ExtractAppliancesInto interprets the results of a single page from a List() call,
+// producing a slice of Server entities.
+func ExtractAppliancesInto(r pagination.Page, v interface{}) error {
+	return r.(AppliancePage).Result.ExtractIntoSlicePtr(v, "virtual_network_appliances")
+}

--- a/ecl/vna/v1/appliances/results.go
+++ b/ecl/vna/v1/appliances/results.go
@@ -46,11 +46,15 @@ type DeleteResult struct {
 	eclcloud.ErrResult
 }
 
+// FixedIPInResponse represents each element of fixed ips
+// of virtual network appliance.
 type FixedIPInResponse struct {
 	IPAddress string `json:"ip_address"`
 	SubnetID  string `json:"subnet_id"`
 }
 
+// AllowedAddressPairInResponse represents each element of
+// allowed address pair of virtual network appliance.
 type AllowedAddressPairInResponse struct {
 	IPAddress  string      `json:"ip_address"`
 	MACAddress string      `json:"mac_address"`
@@ -58,6 +62,8 @@ type AllowedAddressPairInResponse struct {
 	VRID       interface{} `json:"vrid"`
 }
 
+// InterfaceInResponse works as parent element of
+// each interface of virtual network appliance.
 type InterfaceInResponse struct {
 	Name                string                         `json:"name"`
 	Description         string                         `json:"description"`
@@ -68,6 +74,8 @@ type InterfaceInResponse struct {
 	AllowedAddressPairs []AllowedAddressPairInResponse `json:"allowed_address_pairs"`
 }
 
+// InterfacesInResponse works as list of interfaces
+// of virtual network appliance.
 type InterfacesInResponse struct {
 	Interface1 InterfaceInResponse `json:"interface_1"`
 	Interface2 InterfaceInResponse `json:"interface_2"`

--- a/ecl/vna/v1/appliances/testing/doc.go
+++ b/ecl/vna/v1/appliances/testing/doc.go
@@ -1,0 +1,2 @@
+// Package testing contains virtual network appliance unit tests
+package testing

--- a/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/ecl/vna/v1/appliances/testing/fixtures.go
@@ -760,3 +760,149 @@ var updateNetworkIDAndFixedIPResponse = fmt.Sprintf(`
 	idAppliance1,
 	idVirtualNetworkAppliancePlan,
 )
+
+var updateAllowedAddressPairsRequest = fmt.Sprintf(`
+    {
+        "virtual_network_appliance": {
+            "interfaces": {
+                "interface_1": {
+                    "allowed_address_pairs": [
+                        {
+                            "ip_address": "1.1.1.1",
+                            "mac_address": "aa:bb:cc:dd:ee:f1",
+                            "type": "vrrp",
+                            "vrid": 123
+                        },
+                        {
+                            "ip_address": "2.2.2.2",
+                            "mac_address": "aa:bb:cc:dd:ee:f2",
+                            "type": "",
+                            "vrid": null
+                        }
+                    ]
+                }
+            }
+        }
+    }`,
+)
+
+var updateAllowedAddressPairsResponse = fmt.Sprintf(`
+{
+    "virtual_network_appliance": {
+        "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+        "availability_zone": "zone1-groupb",
+        "default_gateway": "192.168.1.1",
+        "description": "appliance_1_description",
+        "id": "%s",
+        "interfaces": {
+            "interface_1": {
+                "allowed_address_pairs": [
+                    {
+                        "ip_address": "1.1.1.1",
+                        "mac_address": "aa:bb:cc:dd:ee:f1",
+                        "type": "vrrp",
+                        "vrid": 123
+                    },
+                    {
+                        "ip_address": "2.2.2.2",
+                        "mac_address": "aa:bb:cc:dd:ee:f2",
+                        "type": "",
+                        "vrid": null
+                    }
+                ],
+                "description": "interface_1_description",
+                "fixed_ips": [
+                    {
+                        "ip_address": "192.168.1.51",
+                        "subnet_id": "dummySubnetID"
+                    }
+                ],
+                "name": "interface_1",
+                "network_id": "dummyNetworkID",
+                "tags": {
+                    "k1": "v1"
+                },
+                "updatable": true
+            },
+            "interface_2": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_3": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_4": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_5": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_6": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_7": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_8": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            }
+        },
+        "name": "appliance_1",
+        "operation_status": "COMPLETE",
+        "os_login_status": "ACTIVE",
+        "os_monitoring_status": "ACTIVE",
+        "password": "Passw0rd",
+        "tags": {
+            "k1": "v1",
+            "k2": "v2"
+        },
+        "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
+        "username": "root",
+        "virtual_network_appliance_plan_id": "%s",
+        "vm_status": "ACTIVE"
+    }
+}`,
+	idAppliance1,
+	idVirtualNetworkAppliancePlan,
+)

--- a/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/ecl/vna/v1/appliances/testing/fixtures.go
@@ -621,3 +621,142 @@ var updateMetadataResponse = fmt.Sprintf(`
 	idAppliance1,
 	idVirtualNetworkAppliancePlan,
 )
+
+var updateNetworkIDAndFixedIPRequest = fmt.Sprintf(`
+    {
+        "virtual_network_appliance": {
+            "interfaces": {
+                "interface_1": {
+                    "network_id": "dummyNetworkID2",
+                    "fixed_ips": [
+                        {
+                            "ip_address": "192.168.1.51"
+                        },
+                        {
+                            "ip_address": "192.168.1.52"
+                        }
+                    ]
+                }
+            }
+        }
+    }`,
+)
+
+var updateNetworkIDAndFixedIPResponse = fmt.Sprintf(`
+{
+    "virtual_network_appliance": {
+        "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+        "availability_zone": "zone1-groupb",
+        "default_gateway": "192.168.1.1",
+        "description": "appliance_1_description",
+        "id": "%s",
+        "interfaces": {
+            "interface_1": {
+                "allowed_address_pairs": [
+                    {
+                        "ip_address": "1.1.1.1",
+                        "mac_address": "aa:bb:cc:dd:ee:f1",
+                        "type": "vrrp",
+                        "vrid": 123
+                    }
+                ],
+                "description": "interface_1_description",
+                "fixed_ips": [
+                    {
+                        "ip_address": "192.168.1.51",
+                        "subnet_id": "dummySubnetID"
+                    },
+                    {
+                        "ip_address": "192.168.1.52",
+                        "subnet_id": "dummySubnetID"
+                    }
+                ],
+                "name": "interface_1",
+                "network_id": "dummyNetworkID2",
+                "tags": {
+                    "k1": "v1"
+                },
+                "updatable": true
+            },
+            "interface_2": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_3": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_4": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_5": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_6": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_7": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_8": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            }
+        },
+        "name": "appliance_1",
+        "operation_status": "COMPLETE",
+        "os_login_status": "ACTIVE",
+        "os_monitoring_status": "ACTIVE",
+        "password": "Passw0rd",
+        "tags": {
+            "k1": "v1",
+            "k2": "v2"
+        },
+        "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
+        "username": "root",
+        "virtual_network_appliance_plan_id": "%s",
+        "vm_status": "ACTIVE"
+    }
+}`,
+	idAppliance1,
+	idVirtualNetworkAppliancePlan,
+)

--- a/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/ecl/vna/v1/appliances/testing/fixtures.go
@@ -1,0 +1,343 @@
+package testing
+
+import (
+	"fmt"
+
+	"github.com/nttcom/eclcloud/ecl/vna/v1/appliances"
+)
+
+const applianceType = "ECL::VirtualNetworkAppliance::VSRX"
+const idAppliance1 = "45db3e66-31af-45a6-8ad2-d01521726141"
+const idAppliance2 = "45db3e66-31af-45a6-8ad2-d01521726142"
+
+const idVirtualNetworkAppliancePlan = "6589b37a-cf82-4918-96fe-255683f78e76"
+
+var listResponse = fmt.Sprintf(`
+{
+    "virtual_network_appliances": [
+        {
+            "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+            "availability_zone": "zone1-groupb",
+            "default_gateway": "192.168.1.1",
+            "description": "appliance_1_description",
+            "id": "%s",
+            "interfaces": {
+                "interface_1": {
+                    "allowed_address_pairs": [
+                        {
+                            "ip_address": "1.1.1.1",
+                            "mac_address": "aa:bb:cc:dd:ee:f1",
+                            "type": "vrrp",
+                            "vrid": 123
+                        }
+                    ],
+                    "description": "interface_1_description",
+                    "fixed_ips": [
+                        {
+                            "ip_address": "192.168.1.51",
+                            "subnet_id": "dummySubnetID"
+                        }
+                    ],
+                    "name": "interface_1",
+                    "network_id": "dummyNetworkID",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_2": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_3": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_4": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_5": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_6": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_7": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_8": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                }
+            },
+            "name": "appliance_1",
+            "operation_status": "COMPLETE",
+            "os_login_status": "ACTIVE",
+            "os_monitoring_status": "ACTIVE",
+            "password": "Passw0rd",
+            "tags": {
+                "k1": "v1"
+            },
+            "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
+            "username": "root",
+            "virtual_network_appliance_plan_id": "%s",
+            "vm_status": "ACTIVE"
+        },
+        {
+            "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+            "availability_zone": "zone1-groupb",
+            "default_gateway": "192.168.1.1",
+            "description": "appliance_2_description",
+            "id": "%s",
+            "interfaces": {
+                "interface_1": {
+                    "allowed_address_pairs": [
+                        {
+                            "ip_address": "2.2.2.2",
+                            "mac_address": "aa:bb:cc:dd:ee:f2",
+                            "type": "",
+                            "vrid": null
+                        }
+                    ],
+                    "description": "interface_1_description",
+                    "fixed_ips": [
+                        {
+                            "ip_address": "192.168.1.52",
+                            "subnet_id": "dummySubnetID"
+                        }
+                    ],
+                    "name": "interface_1",
+                    "network_id": "dummyNetworkID",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_2": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_3": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_4": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_5": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_6": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_7": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                },
+                "interface_8": {
+                    "allowed_address_pairs": [],
+                    "description": "",
+                    "fixed_ips": [],
+                    "name": "",
+                    "network_id": "",
+                    "tags": {},
+                    "updatable": true
+                }
+            },
+            "name": "appliance_2",
+            "operation_status": "COMPLETE",
+            "os_login_status": "ACTIVE",
+            "os_monitoring_status": "ACTIVE",
+            "password": "Passw0rd",
+            "tags": {
+                "k1": "v1"
+            },
+            "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
+            "username": "root",
+            "virtual_network_appliance_plan_id": "%s",
+            "vm_status": "ACTIVE"
+        }
+    ]
+}`,
+	// for appliance1
+	idAppliance1,
+	idVirtualNetworkAppliancePlan,
+	// for appliance2
+	idAppliance2,
+	idVirtualNetworkAppliancePlan,
+)
+
+var defaultInterface = appliances.InterfaceInResponse{
+	Name:                "",
+	Description:         "",
+	NetworkID:           "",
+	Updatable:           true,
+	Tags:                map[string]string{},
+	FixedIPs:            []appliances.FixedIPInResponse{},
+	AllowedAddressPairs: []appliances.AllowedAddressPairInResponse{},
+}
+
+var appliance1 = appliances.Appliance{
+	ID:                 idAppliance1,
+	Name:               "appliance_1",
+	ApplianceType:      applianceType,
+	Description:        "appliance_1_description",
+	DefaultGateway:     "192.168.1.1",
+	AvailabilityZone:   "zone1-groupb",
+	OSMonitoringStatus: "ACTIVE",
+	OSLoginStatus:      "ACTIVE",
+	VMStatus:           "ACTIVE",
+	OperationStatus:    "COMPLETE",
+	AppliancePlanID:    idVirtualNetworkAppliancePlan,
+	TenantID:           "9ee80f2a926c49f88f166af47df4e9f5",
+	Tags:               map[string]string{"k1": "v1"},
+	Interfaces: appliances.InterfacesInResponse{
+		Interface1: appliances.InterfaceInResponse{
+			Name:        "interface_1",
+			Description: "interface_1_description",
+			NetworkID:   "dummyNetworkID",
+			Tags:        map[string]string{},
+			Updatable:   true,
+			FixedIPs: []appliances.FixedIPInResponse{
+				appliances.FixedIPInResponse{
+					IPAddress: "192.168.1.51",
+					SubnetID:  "dummySubnetID",
+				},
+			},
+			AllowedAddressPairs: []appliances.AllowedAddressPairInResponse{
+				appliances.AllowedAddressPairInResponse{
+					IPAddress:  "1.1.1.1",
+					MACAddress: "aa:bb:cc:dd:ee:f1",
+					Type:       "vrrp",
+					VRID:       float64(123),
+				},
+			},
+		},
+		Interface2: defaultInterface,
+		Interface3: defaultInterface,
+		Interface4: defaultInterface,
+		Interface5: defaultInterface,
+		Interface6: defaultInterface,
+		Interface7: defaultInterface,
+		Interface8: defaultInterface,
+	},
+}
+
+var appliance2 = appliances.Appliance{
+	ID:                 idAppliance2,
+	Name:               "appliance_2",
+	ApplianceType:      applianceType,
+	Description:        "appliance_2_description",
+	DefaultGateway:     "192.168.1.1",
+	AvailabilityZone:   "zone1-groupb",
+	OSMonitoringStatus: "ACTIVE",
+	OSLoginStatus:      "ACTIVE",
+	VMStatus:           "ACTIVE",
+	OperationStatus:    "COMPLETE",
+	AppliancePlanID:    idVirtualNetworkAppliancePlan,
+	TenantID:           "9ee80f2a926c49f88f166af47df4e9f5",
+	Tags:               map[string]string{"k1": "v1"},
+	Interfaces: appliances.InterfacesInResponse{
+		Interface1: appliances.InterfaceInResponse{
+			Name:        "interface_1",
+			Description: "interface_1_description",
+			NetworkID:   "dummyNetworkID",
+			Tags:        map[string]string{},
+			Updatable:   true,
+			FixedIPs: []appliances.FixedIPInResponse{
+				appliances.FixedIPInResponse{
+					IPAddress: "192.168.1.52",
+					SubnetID:  "dummySubnetID",
+				},
+			},
+			AllowedAddressPairs: []appliances.AllowedAddressPairInResponse{
+				appliances.AllowedAddressPairInResponse{
+					IPAddress:  "2.2.2.2",
+					MACAddress: "aa:bb:cc:dd:ee:f2",
+					Type:       "",
+					VRID:       interface{}(nil),
+				},
+			},
+		},
+		Interface2: defaultInterface,
+		Interface3: defaultInterface,
+		Interface4: defaultInterface,
+		Interface5: defaultInterface,
+		Interface6: defaultInterface,
+		Interface7: defaultInterface,
+		Interface8: defaultInterface,
+	},
+}
+
+var expectedAppliancesSlice = []appliances.Appliance{
+	appliance1,
+	appliance2,
+}

--- a/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/ecl/vna/v1/appliances/testing/fixtures.go
@@ -482,3 +482,142 @@ var createRequest = fmt.Sprintf(`
 )
 
 var createResponse = getResponse
+
+var updateMetadataRequest = fmt.Sprintf(`
+    {
+        "virtual_network_appliance": {
+            "name": "appliance_1-update",
+            "description": "appliance_1_description-update",
+            "tags": {
+                "k1": "v1",
+                "k2": "v2"
+            },
+            "interfaces": {
+                "interface_1": {
+                    "name": "interface_1",
+                    "description": "interface_1_description",
+                    "tags": {
+                        "k1": "v1",
+                        "k2": "v2"
+                    }
+                }
+            }
+        }
+    }`,
+)
+
+var updateMetadataResponse = fmt.Sprintf(`
+{
+    "virtual_network_appliance": {
+        "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+        "availability_zone": "zone1-groupb",
+        "default_gateway": "192.168.1.1",
+        "description": "appliance_1_description-update",
+        "id": "%s",
+        "interfaces": {
+            "interface_1": {
+                "allowed_address_pairs": [
+                    {
+                        "ip_address": "1.1.1.1",
+                        "mac_address": "aa:bb:cc:dd:ee:f1",
+                        "type": "vrrp",
+                        "vrid": 123
+                    }
+                ],
+                "description": "interface_1_description",
+                "fixed_ips": [
+                    {
+                        "ip_address": "192.168.1.51",
+                        "subnet_id": "dummySubnetID"
+                    }
+                ],
+                "name": "interface_1",
+                "network_id": "dummyNetworkID",
+                "tags": {
+                    "k1": "v1",
+                    "k2": "v2"
+                },
+                "updatable": true
+            },
+            "interface_2": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_3": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_4": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_5": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_6": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_7": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_8": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            }
+        },
+        "name": "appliance_1-update",
+        "operation_status": "COMPLETE",
+        "os_login_status": "ACTIVE",
+        "os_monitoring_status": "ACTIVE",
+        "password": "Passw0rd",
+        "tags": {
+            "k1": "v1",
+            "k2": "v2"
+        },
+        "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
+        "username": "root",
+        "virtual_network_appliance_plan_id": "%s",
+        "vm_status": "ACTIVE"
+    }
+}`,
+	idAppliance1,
+	idVirtualNetworkAppliancePlan,
+)

--- a/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/ecl/vna/v1/appliances/testing/fixtures.go
@@ -449,7 +449,36 @@ var getResponse = fmt.Sprintf(`
         "virtual_network_appliance_plan_id": "%s",
         "vm_status": "ACTIVE"
     }
-}`, 
-    idAppliance1,
-    idVirtualNetworkAppliancePlan,
+}`,
+	idAppliance1,
+	idVirtualNetworkAppliancePlan,
 )
+
+var createRequest = fmt.Sprintf(`
+    {
+    	"virtual_network_appliance": {
+    		"name": "appliance_1",
+    		"description": "appliance_1_description",
+    		"availability_zone": "zone1-groupb",
+    		"default_gateway": "192.168.1.1",
+    		"interfaces": {
+    			"interface_1": {
+    				"name": "interface_1",
+    				"description": "interface_1_description",
+    				"fixed_ips": [{
+    					"ip_address": "192.168.1.51"
+    				}],
+    				"network_id": "dummyNetworkID"
+    			}
+    		},
+    		"tags": {
+    			"k1": "v1"
+    		},
+    		"virtual_network_appliance_plan_id": "%s"
+    	}
+    }
+`,
+	idVirtualNetworkAppliancePlan,
+)
+
+var createResponse = getResponse

--- a/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/ecl/vna/v1/appliances/testing/fixtures.go
@@ -341,3 +341,115 @@ var expectedAppliancesSlice = []appliances.Appliance{
 	appliance1,
 	appliance2,
 }
+
+var getResponse = fmt.Sprintf(`
+{
+    "virtual_network_appliance": {
+        "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+        "availability_zone": "zone1-groupb",
+        "default_gateway": "192.168.1.1",
+        "description": "appliance_1_description",
+        "id": "%s",
+        "interfaces": {
+            "interface_1": {
+                "allowed_address_pairs": [
+                    {
+                        "ip_address": "1.1.1.1",
+                        "mac_address": "aa:bb:cc:dd:ee:f1",
+                        "type": "vrrp",
+                        "vrid": 123
+                    }
+                ],
+                "description": "interface_1_description",
+                "fixed_ips": [
+                    {
+                        "ip_address": "192.168.1.51",
+                        "subnet_id": "dummySubnetID"
+                    }
+                ],
+                "name": "interface_1",
+                "network_id": "dummyNetworkID",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_2": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_3": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_4": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_5": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_6": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_7": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            },
+            "interface_8": {
+                "allowed_address_pairs": [],
+                "description": "",
+                "fixed_ips": [],
+                "name": "",
+                "network_id": "",
+                "tags": {},
+                "updatable": true
+            }
+        },
+        "name": "appliance_1",
+        "operation_status": "COMPLETE",
+        "os_login_status": "ACTIVE",
+        "os_monitoring_status": "ACTIVE",
+        "password": "Passw0rd",
+        "tags": {
+            "k1": "v1"
+        },
+        "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
+        "username": "root",
+        "virtual_network_appliance_plan_id": "%s",
+        "vm_status": "ACTIVE"
+    }
+}`, 
+    idAppliance1,
+    idVirtualNetworkAppliancePlan,
+)

--- a/ecl/vna/v1/appliances/testing/requests_test.go
+++ b/ecl/vna/v1/appliances/testing/requests_test.go
@@ -249,3 +249,84 @@ func TestUpdateApplianceNetworkIDAndFixedIP(t *testing.T) {
 	th.AssertEquals(t, ap.Interfaces.Interface1.FixedIPs[1].IPAddress, "192.168.1.52")
 	th.AssertEquals(t, ap.ID, idAppliance1)
 }
+func TestUpdateApplianceAllowedAddressPairs(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	url := fmt.Sprintf("/v1.0/virtual_network_appliances/%s", idAppliance1)
+	th.Mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, updateAllowedAddressPairsRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, updateAllowedAddressPairsResponse)
+	})
+
+	mac1 := "aa:bb:cc:dd:ee:f1"
+	type1 := "vrrp"
+
+	var vrid1 interface{}
+	vrid1 = 123
+
+	UpdateAllowedAddressPairAddressInfo1 := appliances.UpdateAllowedAddressPairAddressInfo{
+		IPAddress:  "1.1.1.1",
+		MACAddress: &mac1,
+		Type:       &type1,
+		VRID:       &vrid1,
+	}
+
+	mac2 := "aa:bb:cc:dd:ee:f2"
+	type2 := ""
+
+	var vrid2 interface{}
+	vrid2 = interface{}(nil)
+
+	UpdateAllowedAddressPairAddressInfo2 := appliances.UpdateAllowedAddressPairAddressInfo{
+		IPAddress:  "2.2.2.2",
+		MACAddress: &mac2,
+		Type:       &type2,
+		VRID:       &vrid2,
+	}
+
+	updateAllowedAddressPairs := []appliances.UpdateAllowedAddressPairAddressInfo{
+		UpdateAllowedAddressPairAddressInfo1,
+		UpdateAllowedAddressPairAddressInfo2,
+	}
+
+	updateOptsInterface1 := appliances.UpdateAllowedAddressPairInterface{
+		AllowedAddressPairs: &updateAllowedAddressPairs,
+	}
+
+	updateOpts := appliances.UpdateAllowedAddressPairOpts{
+		Interfaces: appliances.UpdateAllowedAddressPairInterfaces{
+			Interface1: updateOptsInterface1,
+			Interface2: interface{}(nil),
+			Interface3: interface{}(nil),
+			Interface4: interface{}(nil),
+			Interface5: interface{}(nil),
+			Interface6: interface{}(nil),
+			Interface7: interface{}(nil),
+			Interface8: interface{}(nil),
+		},
+	}
+	ap, err := appliances.Update(
+		ServiceClient(), idAppliance1, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, ap.Interfaces.Interface1.AllowedAddressPairs[0].IPAddress, "1.1.1.1")
+	th.AssertEquals(t, ap.Interfaces.Interface1.AllowedAddressPairs[0].MACAddress, "aa:bb:cc:dd:ee:f1")
+	th.AssertEquals(t, ap.Interfaces.Interface1.AllowedAddressPairs[0].Type, "vrrp")
+	th.AssertEquals(t, ap.Interfaces.Interface1.AllowedAddressPairs[0].VRID, float64(123))
+
+	th.AssertEquals(t, ap.Interfaces.Interface1.AllowedAddressPairs[1].IPAddress, "2.2.2.2")
+	th.AssertEquals(t, ap.Interfaces.Interface1.AllowedAddressPairs[1].MACAddress, "aa:bb:cc:dd:ee:f2")
+	th.AssertEquals(t, ap.Interfaces.Interface1.AllowedAddressPairs[1].Type, "")
+	th.AssertEquals(t, ap.Interfaces.Interface1.AllowedAddressPairs[1].VRID, interface{}(nil))
+
+	th.AssertEquals(t, ap.ID, idAppliance1)
+}

--- a/ecl/vna/v1/appliances/testing/requests_test.go
+++ b/ecl/vna/v1/appliances/testing/requests_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/nttcom/eclcloud"
 	"github.com/nttcom/eclcloud/ecl/vna/v1/appliances"
-	"github.com/nttcom/eclcloud/pagination"
 	"github.com/nttcom/eclcloud/testhelper/client"
+	"github.com/nttcom/eclcloud/pagination"
 
 	th "github.com/nttcom/eclcloud/testhelper"
 )
@@ -120,4 +120,19 @@ func TestCreateAppliance(t *testing.T) {
 
 	th.AssertEquals(t, ap.OperationStatus, "COMPLETE")
 	th.AssertDeepEquals(t, &appliance1, ap)
+}
+
+func TestDeleteAppliance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	url := fmt.Sprintf("/v1.0/virtual_network_appliances/%s", idAppliance1)
+	th.Mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := appliances.Delete(ServiceClient(), idAppliance1)
+	th.AssertNoErr(t, res.Err)
 }

--- a/ecl/vna/v1/appliances/testing/requests_test.go
+++ b/ecl/vna/v1/appliances/testing/requests_test.go
@@ -172,15 +172,8 @@ func TestUpdateApplianceMetadata(t *testing.T) {
 		Name:        &name,
 		Description: &description,
 		Tags:        &tags,
-		Interfaces: appliances.UpdateMetadataInterfaces{
-			Interface1: updateOptsInterface1,
-			Interface2: interface{}(nil),
-			Interface3: interface{}(nil),
-			Interface4: interface{}(nil),
-			Interface5: interface{}(nil),
-			Interface6: interface{}(nil),
-			Interface7: interface{}(nil),
-			Interface8: interface{}(nil),
+		Interfaces: &appliances.UpdateMetadataInterfaces{
+			Interface1: &updateOptsInterface1,
 		},
 	}
 	ap, err := appliances.Update(
@@ -229,15 +222,8 @@ func TestUpdateApplianceNetworkIDAndFixedIP(t *testing.T) {
 		FixedIPs:  &updateFixedIPs,
 	}
 	updateOpts := appliances.UpdateFixedIPOpts{
-		Interfaces: appliances.UpdateFixedIPInterfaces{
-			Interface1: updateOptsInterface1,
-			Interface2: interface{}(nil),
-			Interface3: interface{}(nil),
-			Interface4: interface{}(nil),
-			Interface5: interface{}(nil),
-			Interface6: interface{}(nil),
-			Interface7: interface{}(nil),
-			Interface8: interface{}(nil),
+		Interfaces: &appliances.UpdateFixedIPInterfaces{
+			Interface1: &updateOptsInterface1,
 		},
 	}
 	ap, err := appliances.Update(
@@ -303,15 +289,8 @@ func TestUpdateApplianceAllowedAddressPairs(t *testing.T) {
 	}
 
 	updateOpts := appliances.UpdateAllowedAddressPairOpts{
-		Interfaces: appliances.UpdateAllowedAddressPairInterfaces{
-			Interface1: updateOptsInterface1,
-			Interface2: interface{}(nil),
-			Interface3: interface{}(nil),
-			Interface4: interface{}(nil),
-			Interface5: interface{}(nil),
-			Interface6: interface{}(nil),
-			Interface7: interface{}(nil),
-			Interface8: interface{}(nil),
+		Interfaces: &appliances.UpdateAllowedAddressPairInterfaces{
+			Interface1: &updateOptsInterface1,
 		},
 	}
 	ap, err := appliances.Update(

--- a/ecl/vna/v1/appliances/testing/requests_test.go
+++ b/ecl/vna/v1/appliances/testing/requests_test.go
@@ -57,3 +57,23 @@ func TestListAppliances(t *testing.T) {
 		t.Errorf("Expected 1 page, got %d", count)
 	}
 }
+
+func TestGetAppliance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	url := fmt.Sprintf("/v1.0/virtual_network_appliances/%s", idAppliance1)
+	th.Mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, getResponse)
+	})
+
+	ap, err := appliances.Get(ServiceClient(), idAppliance1).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &appliance1, ap)
+}

--- a/ecl/vna/v1/appliances/testing/requests_test.go
+++ b/ecl/vna/v1/appliances/testing/requests_test.go
@@ -1,0 +1,59 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/ecl/vna/v1/appliances"
+	"github.com/nttcom/eclcloud/pagination"
+	"github.com/nttcom/eclcloud/testhelper/client"
+
+	th "github.com/nttcom/eclcloud/testhelper"
+)
+
+const TokenID = client.TokenID
+
+func ServiceClient() *eclcloud.ServiceClient {
+	sc := client.ServiceClient()
+	sc.ResourceBase = sc.Endpoint + "v1.0/"
+	return sc
+}
+
+func TestListAppliances(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc(
+		"/v1.0/virtual_network_appliances",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", TokenID)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprintf(w, listResponse)
+		})
+
+	client := ServiceClient()
+	count := 0
+
+	appliances.List(client, appliances.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := appliances.ExtractAppliances(page)
+		if err != nil {
+			t.Errorf("Failed to extract virtual network appliances: %v", err)
+			return false, err
+		}
+
+		th.CheckDeepEquals(t, expectedAppliancesSlice, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/ecl/vna/v1/appliances/urls.go
+++ b/ecl/vna/v1/appliances/urls.go
@@ -1,0 +1,33 @@
+package appliances
+
+import (
+	"github.com/nttcom/eclcloud"
+)
+
+func resourceURL(c *eclcloud.ServiceClient, id string) string {
+	return c.ServiceURL("virtual_network_appliances", id)
+}
+
+func rootURL(c *eclcloud.ServiceClient) string {
+	return c.ServiceURL("virtual_network_appliances")
+}
+
+func getURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func createURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Result of unit tests.

```
% go test ./... | grep -v "no test files"                                                                                                                           (git)-[vsrx_support]
ok  	github.com/nttcom/eclcloud/ecl/compute/v2/extensions/availabilityzones/testing	0.029s
ok  	github.com/nttcom/eclcloud/ecl/compute/v2/extensions/bootfromvolume/testing	0.044s
ok  	github.com/nttcom/eclcloud/ecl/compute/v2/extensions/keypairs/testing	0.043s
ok  	github.com/nttcom/eclcloud/ecl/compute/v2/extensions/startstop/testing	0.037s
ok  	github.com/nttcom/eclcloud/ecl/compute/v2/extensions/volumeattach/testing	0.044s
ok  	github.com/nttcom/eclcloud/ecl/computevolume/extensions/volumeactions/testing	0.033s
ok  	github.com/nttcom/eclcloud/ecl/computevolume/v2/volumes/testing	0.045s
ok  	github.com/nttcom/eclcloud/ecl/dns/v2/recordsets/testing	0.062s
ok  	github.com/nttcom/eclcloud/ecl/dns/v2/zones/testing	0.037s
ok  	github.com/nttcom/eclcloud/ecl/imagestorage/v2/imagedata/testing	0.035s
ok  	github.com/nttcom/eclcloud/ecl/imagestorage/v2/images/testing	0.057s
ok  	github.com/nttcom/eclcloud/ecl/imagestorage/v2/members/testing	0.048s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/common_function_gateways/testing	0.045s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/gateway_interfaces/testing	0.039s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/internet_gateways/testing	0.080s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/internet_services/testing	0.046s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/networks/testing	0.044s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/ports/testing	0.041s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/public_ips/testing	0.041s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/static_routes/testing	0.049s
ok  	github.com/nttcom/eclcloud/ecl/network/v2/subnets/testing	0.047s
ok  	github.com/nttcom/eclcloud/ecl/sss/v1/tenants/testing	0.036s
ok  	github.com/nttcom/eclcloud/ecl/sss/v1/users/testing	0.064s
ok  	github.com/nttcom/eclcloud/ecl/storage/v1/virtualstorages/testing	0.074s
ok  	github.com/nttcom/eclcloud/ecl/storage/v1/volumes/testing	0.032s
ok  	github.com/nttcom/eclcloud/ecl/storage/v1/volumetypes/testing	0.028s
ok  	github.com/nttcom/eclcloud/ecl/vna/v1/appliances/testing	0.029s <-- added this part.
```