### PR TITLE
Fix Load Balancer request and response format

### DIFF
--- a/ecl/network/v2/load_balancer_interfaces/requests.go
+++ b/ecl/network/v2/load_balancer_interfaces/requests.go
@@ -61,19 +61,19 @@ type UpdateOpts struct {
 	Description *string `json:"description,omitempty"`
 
 	// IP Address
-	IPAddress string `json:"ip_address,omitempty"`
+	IPAddress *interface{} `json:"ip_address,omitempty"`
 
 	// Name of the Load Balancer Interface
 	Name *string `json:"name,omitempty"`
 
 	// UUID of the parent network.
-	NetworkID string `json:"network_id,omitempty"`
+	NetworkID *interface{} `json:"network_id,omitempty"`
 
 	// Virtual IP Address
-	VirtualIPAddress string `json:"virtual_ip_address,omitempty"`
+	VirtualIPAddress *interface{} `json:"virtual_ip_address,omitempty"`
 
 	// Properties used for virtual IP address
-	VirtualIPProperties VirtualIPProperties `json:"virtual_ip_properties,omitempty"`
+	VirtualIPProperties *VirtualIPProperties `json:"virtual_ip_properties,omitempty"`
 }
 
 // ToLoadBalancerUpdateMap builds a request body from UpdateOpts.

--- a/ecl/network/v2/load_balancer_interfaces/requests.go
+++ b/ecl/network/v2/load_balancer_interfaces/requests.go
@@ -61,7 +61,7 @@ type UpdateOpts struct {
 	Description *string `json:"description,omitempty"`
 
 	// IP Address
-	IPAddress *interface{} `json:"ip_address,omitempty"`
+	IPAddress string `json:"ip_address,omitempty"`
 
 	// Name of the Load Balancer Interface
 	Name *string `json:"name,omitempty"`

--- a/ecl/network/v2/load_balancer_interfaces/testing/fixtures.go
+++ b/ecl/network/v2/load_balancer_interfaces/testing/fixtures.go
@@ -1,7 +1,7 @@
 package testing
 
 import (
-	load_balancer_interfaces "github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces"
+	"github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces"
 )
 
 const ListResponse = `

--- a/ecl/network/v2/load_balancer_interfaces/testing/request_test.go
+++ b/ecl/network/v2/load_balancer_interfaces/testing/request_test.go
@@ -83,8 +83,7 @@ func TestUpdateLoadBalancerInterface(t *testing.T) {
 	})
 
 	description := "test"
-	var ipAddress interface{}
-	ipAddress = "100.64.64.34"
+	ipAddress := "100.64.64.34"
 	name := "Interface 1/2"
 	var networkID interface{}
 	networkID = "e6106a35-d79b-44a3-bda0-6009b2f8775a"
@@ -106,7 +105,7 @@ func TestUpdateLoadBalancerInterface(t *testing.T) {
 
 	options := load_balancer_interfaces.UpdateOpts{
 		Description:         &description,
-		IPAddress:           &ipAddress,
+		IPAddress:           ipAddress,
 		Name:                &name,
 		NetworkID:           &networkID,
 		VirtualIPAddress:    &virtualIPAddress,

--- a/ecl/network/v2/load_balancer_interfaces/testing/request_test.go
+++ b/ecl/network/v2/load_balancer_interfaces/testing/request_test.go
@@ -85,10 +85,8 @@ func TestUpdateLoadBalancerInterface(t *testing.T) {
 	description := "test"
 	ipAddress := "100.64.64.34"
 	name := "Interface 1/2"
-	var networkID interface{}
-	networkID = "e6106a35-d79b-44a3-bda0-6009b2f8775a"
-	var virtualIPAddress interface{}
-	virtualIPAddress = "100.64.64.101"
+	networkID := interface{}("e6106a35-d79b-44a3-bda0-6009b2f8775a")
+	virtualIPAddress := interface{}("100.64.64.101")
 	virtualIPProperties := load_balancer_interfaces.VirtualIPProperties{
 		Protocol: "vrrp",
 		Vrid:     10,

--- a/ecl/network/v2/load_balancer_interfaces/testing/request_test.go
+++ b/ecl/network/v2/load_balancer_interfaces/testing/request_test.go
@@ -2,11 +2,11 @@ package testing
 
 import (
 	"fmt"
-	load_balancer_interfaces "github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces"
 	"net/http"
 	"testing"
 
 	fake "github.com/nttcom/eclcloud/ecl/network/v2/common"
+	"github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces"
 	"github.com/nttcom/eclcloud/pagination"
 	th "github.com/nttcom/eclcloud/testhelper"
 )

--- a/ecl/network/v2/load_balancer_interfaces/testing/request_test.go
+++ b/ecl/network/v2/load_balancer_interfaces/testing/request_test.go
@@ -83,10 +83,13 @@ func TestUpdateLoadBalancerInterface(t *testing.T) {
 	})
 
 	description := "test"
-	ipAddress := "100.64.64.34"
+	var ipAddress interface{}
+	ipAddress = "100.64.64.34"
 	name := "Interface 1/2"
-	networkID := "e6106a35-d79b-44a3-bda0-6009b2f8775a"
-	virtualIPAddress := "100.64.64.101"
+	var networkID interface{}
+	networkID = "e6106a35-d79b-44a3-bda0-6009b2f8775a"
+	var virtualIPAddress interface{}
+	virtualIPAddress = "100.64.64.101"
 	virtualIPProperties := load_balancer_interfaces.VirtualIPProperties{
 		Protocol: "vrrp",
 		Vrid:     10,
@@ -103,11 +106,11 @@ func TestUpdateLoadBalancerInterface(t *testing.T) {
 
 	options := load_balancer_interfaces.UpdateOpts{
 		Description:         &description,
-		IPAddress:           ipAddress,
+		IPAddress:           &ipAddress,
 		Name:                &name,
-		NetworkID:           "e6106a35-d79b-44a3-bda0-6009b2f8775a",
-		VirtualIPAddress:    "100.64.64.101",
-		VirtualIPProperties: virtualIPProperties,
+		NetworkID:           &networkID,
+		VirtualIPAddress:    &virtualIPAddress,
+		VirtualIPProperties: &virtualIPProperties,
 	}
 
 	s, err := load_balancer_interfaces.Update(fake.ServiceClient(), "ab49eb24-667f-4a4e-9421-b4d915bff416", options).Extract()

--- a/ecl/network/v2/load_balancer_plans/testing/fixtures.go
+++ b/ecl/network/v2/load_balancer_plans/testing/fixtures.go
@@ -1,7 +1,7 @@
 package testing
 
 import (
-	load_balancer_plans "github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans"
+	"github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans"
 )
 
 const ListResponse = `

--- a/ecl/network/v2/load_balancer_plans/testing/request_test.go
+++ b/ecl/network/v2/load_balancer_plans/testing/request_test.go
@@ -2,11 +2,11 @@ package testing
 
 import (
 	"fmt"
-	load_balancer_plans "github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans"
 	"net/http"
 	"testing"
 
 	fake "github.com/nttcom/eclcloud/ecl/network/v2/common"
+	"github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans"
 	"github.com/nttcom/eclcloud/pagination"
 	th "github.com/nttcom/eclcloud/testhelper"
 )

--- a/ecl/network/v2/load_balancer_syslog_servers/requests.go
+++ b/ecl/network/v2/load_balancer_syslog_servers/requests.go
@@ -126,7 +126,7 @@ func Create(c *eclcloud.ServiceClient, opts CreateOpts) (r CreateResult) {
 		return
 	}
 	_, r.Err = c.Post(createURL(c), b, &r.Body, &eclcloud.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes: []int{201},
 	})
 	return
 }

--- a/ecl/network/v2/load_balancer_syslog_servers/testing/request_test.go
+++ b/ecl/network/v2/load_balancer_syslog_servers/testing/request_test.go
@@ -76,7 +76,7 @@ func TestCreateLoadBalancerSyslogServer(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestJSONRequest(t, r, CreateRequest)
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusCreated)
 
 		fmt.Fprintf(w, CreateResponse)
 	})

--- a/ecl/network/v2/load_balancers/requests.go
+++ b/ecl/network/v2/load_balancers/requests.go
@@ -93,7 +93,7 @@ func Create(c *eclcloud.ServiceClient, opts CreateOpts) (r CreateResult) {
 		return
 	}
 	_, r.Err = c.Post(createURL(c), b, &r.Body, &eclcloud.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes: []int{201},
 	})
 	return
 }
@@ -102,7 +102,7 @@ func Create(c *eclcloud.ServiceClient, opts CreateOpts) (r CreateResult) {
 type UpdateOpts struct {
 
 	// Description is description
-	DefaultGateway *string `json:"default_gateway,omitempty"`
+	DefaultGateway *interface{} `json:"default_gateway,omitempty"`
 
 	// Description is description
 	Description *string `json:"description,omitempty"`

--- a/ecl/network/v2/load_balancers/testing/fixtures.go
+++ b/ecl/network/v2/load_balancers/testing/fixtures.go
@@ -275,6 +275,9 @@ var DetailVirtualIPAddress1 = "100.127.253.174"
 var DetailIPAddress2 = "192.168.110.1"
 var DetailNetworkID2 = "1839d290-721c-49ba-99f1-3d7aa37811b0"
 
+var VirtualIPPropertiesProtocol = "vrrp"
+var VirtualIPPropertiesVrid = 10
+
 var LoadBalancerDetail = load_balancers.LoadBalancer{
 	ID:               "5f3cae7c-58a5-4124-b622-9ca3cfbf2525",
 	AdminUsername:    "user-admin",
@@ -292,8 +295,8 @@ var LoadBalancerDetail = load_balancers.LoadBalancer{
 			Type:             "user",
 			VirtualIPAddress: &DetailVirtualIPAddress1,
 			VirtualIPProperties: &load_balancer_interfaces.VirtualIPProperties{
-				Protocol: "vrrp",
-				Vrid:     10,
+				Protocol: VirtualIPPropertiesProtocol,
+				Vrid:     VirtualIPPropertiesVrid,
 			},
 		},
 		{

--- a/ecl/network/v2/load_balancers/testing/request_test.go
+++ b/ecl/network/v2/load_balancers/testing/request_test.go
@@ -124,8 +124,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 
 	adminUsername := "user-admin"
 	availabilityZone := "zone1-groupa"
-	var defaultGateway interface{}
-	defaultGateway = "100.127.253.1"
+	defaultGateway := interface{}("100.127.253.1")
 	description := "UPDATED"
 	id := "5f3cae7c-58a5-4124-b622-9ca3cfbf2525"
 

--- a/ecl/network/v2/load_balancers/testing/request_test.go
+++ b/ecl/network/v2/load_balancers/testing/request_test.go
@@ -78,7 +78,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestJSONRequest(t, r, CreateRequest)
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusCreated)
 
 		fmt.Fprintf(w, CreateResponse)
 	})
@@ -124,7 +124,8 @@ func TestUpdateLoadBalancer(t *testing.T) {
 
 	adminUsername := "user-admin"
 	availabilityZone := "zone1-groupa"
-	defaultGateway := "100.127.253.1"
+	var defaultGateway interface{}
+	defaultGateway = "100.127.253.1"
 	description := "UPDATED"
 	id := "5f3cae7c-58a5-4124-b622-9ca3cfbf2525"
 


### PR DESCRIPTION
This PR fixes Load Balancer request/response to match API implementation.
- Change the default_gateway field type in order to send "null"
- Change the Load Balancer Interface field type in order to send "null"
- Change the Create API response OkCodes to 201
