### PR TITLE
Fix gateway interface

### DIFF
--- a/ecl/network/v2/gateway_interfaces/requests.go
+++ b/ecl/network/v2/gateway_interfaces/requests.go
@@ -66,19 +66,16 @@ type CreateOpts struct {
 	AwsGwID       string `json:"aws_gw_id,omitempty"`
 	AzureGwID     string `json:"azure_gw_id,omitempty"`
 	Description   string `json:"description"`
-	FICGatewayID  string `json:"fic_gw_id"`
+	FICGatewayID  string `json:"fic_gw_id,omitempty"`
 	GcpGwID       string `json:"gcp_gw_id,omitempty"`
 	GwVipv4       string `json:"gw_vipv4" required:"true"`
-	GwVipv6       string `json:"gw_vipv6,omitempty"`
 	InterdcGwID   string `json:"interdc_gw_id,omitempty"`
 	InternetGwID  string `json:"internet_gw_id,omitempty"`
 	Name          string `json:"name"`
 	Netmask       int    `json:"netmask" required:"true"`
 	NetworkID     string `json:"network_id" required:"true"`
 	PrimaryIpv4   string `json:"primary_ipv4" required:"true"`
-	PrimaryIpv6   string `json:"primary_ipv6,omitempty"`
 	SecondaryIpv4 string `json:"secondary_ipv4" required:"true"`
-	SecondaryIpv6 string `json:"secondary_ipv6,omitempty"`
 	ServiceType   string `json:"service_type" required:"true"`
 	TenantID      string `json:"tenant_id,omitempty"`
 	VpnGwID       string `json:"vpn_gw_id,omitempty"`

--- a/ecl/network/v2/gateway_interfaces/testing/fixtures.go
+++ b/ecl/network/v2/gateway_interfaces/testing/fixtures.go
@@ -11,7 +11,7 @@ const ListResponse = `
 			"aws_gw_id": null,
 			"azure_gw_id": null,
 			"description": "",
-			"fic_gw_id": "9c5c6441-e174-4b9a-9d16-4ed38cc95dd5",
+			"fic_gw_id": null,
 			"gcp_gw_id": null,
 			"gw_vipv4": "100.127.254.49",
 			"gw_vipv6": null,
@@ -34,14 +34,14 @@ const ListResponse = `
 		{
 			"aws_gw_id": null,
 			"azure_gw_id": null,
-			"description": "lab3-test-user-internet-gateway-interface, role : member",
+			"description": "lab3-test-user-fic-gateway-interface, role : member",
 			"fic_gw_id": "dd04adc4-459f-4fc4-83a5-47436c6aece5",
 			"gcp_gw_id": null,
 			"gw_vipv4": "100.127.254.1",
 			"gw_vipv6": null,
 			"id": "165ed64c-b9d4-46b1-afc1-cbbdc356ddcb",
 			"interdc_gw_id": null,
-			"internet_gw_id": "0ed09319-fe94-4618-8482-23ee254f3d2c",
+			"internet_gw_id": null,
 			"name": "lab3-hara-cfg-20151204",
 			"netmask": 29,
 			"network_id": "cce5c9a1-1ec3-40b1-bfc7-634bb914646b",
@@ -49,7 +49,7 @@ const ListResponse = `
 			"primary_ipv6": null,
 			"secondary_ipv4": "100.127.254.4",
 			"secondary_ipv6": null,
-			"service_type": "internet",
+			"service_type": "fic",
 			"status": "ACTIVE",
 			"tenant_id": "fe1f6fb95b0e48ba8c59be2121a58adc",
 			"vpn_gw_id": null,
@@ -64,7 +64,7 @@ const GetResponse = `
 		"aws_gw_id": null,
 		"azure_gw_id": null,
 		"description": "",
-		"fic_gw_id": "9c5c6441-e174-4b9a-9d16-4ed38cc95dd5",
+		"fic_gw_id": null,
 		"gcp_gw_id": null,
 		"gw_vipv4": "100.127.254.49",
 		"gw_vipv6": null,
@@ -90,7 +90,6 @@ const CreateRequest = `
 {
 	"gw_interface": {
 		"description": "",
-		"fic_gw_id": "9c5c6441-e174-4b9a-9d16-4ed38cc95dd5",
 		"gw_vipv4": "100.127.254.49",
 		"internet_gw_id": "e72ef35a-c96f-45f8-aeee-e7547c5b94b3",
 		"name": "5_Gateway",
@@ -99,7 +98,6 @@ const CreateRequest = `
 		"primary_ipv4": "100.127.254.53",
 		"secondary_ipv4": "100.127.254.54",
 		"service_type": "internet",
-		"tenant_id": "19ab165c7a664abe9c217334cd0e9cc9",
 		"vrid": 1
 	}
 }
@@ -108,19 +106,27 @@ const CreateRequest = `
 const CreateResponse = `
 {
 	"gw_interface": {
+		"aws_gw_id": null,
+		"azure_gw_id": null,
 		"description": "",
-		"fic_gw_id": "9c5c6441-e174-4b9a-9d16-4ed38cc95dd5",
+		"fic_gw_id": null,
+		"gcp_gw_id": null,
 		"gw_vipv4": "100.127.254.49",
+		"gw_vipv6": null,
 		"id": "09771fbb-6496-4ae1-9b53-226b6edcc1be",
+		"interdc_gw_id": null,
 		"internet_gw_id": "e72ef35a-c96f-45f8-aeee-e7547c5b94b3",
 		"name": "5_Gateway",
 		"netmask": 29,
 		"network_id": "0200a550-82cf-4d6d-b564-a87eb63e2b75",
 		"primary_ipv4": "100.127.254.53",
+		"primary_ipv6": null,
 		"secondary_ipv4": "100.127.254.54",
+		"secondary_ipv6": null,
 		"service_type": "internet",
 		"status": "PENDING_CREATE",
 		"tenant_id": "19ab165c7a664abe9c217334cd0e9cc9",
+		"vpn_gw_id": null,
 		"vrid": 1
 	}
 }`
@@ -129,33 +135,40 @@ const UpdateRequest = `
 {
 	"gw_interface": {
 		"description": "Updated",
-		"name": "5_Gateway"
+		"name": "6_Gateway"
 	}
 }`
 
 const UpdateResponse = `
 {
 	"gw_interface": {
+		"aws_gw_id": null,
+		"azure_gw_id": null,
 		"description": "Updated",
-		"fic_gw_id": "9c5c6441-e174-4b9a-9d16-4ed38cc95dd5",
+		"fic_gw_id": null,
+		"gcp_gw_id": null,
 		"gw_vipv4": "100.127.254.49",
+		"gw_vipv6": null,
 		"id": "09771fbb-6496-4ae1-9b53-226b6edcc1be",
+		"interdc_gw_id": null,
 		"internet_gw_id": "e72ef35a-c96f-45f8-aeee-e7547c5b94b3",
-		"name": "5_Gateway",
+		"name": "6_Gateway",
 		"netmask": 29,
 		"network_id": "0200a550-82cf-4d6d-b564-a87eb63e2b75",
 		"primary_ipv4": "100.127.254.53",
+		"primary_ipv6": null,
 		"secondary_ipv4": "100.127.254.54",
+		"secondary_ipv6": null,
 		"service_type": "internet",
 		"status": "PENDING_UPDATE",
 		"tenant_id": "19ab165c7a664abe9c217334cd0e9cc9",
+		"vpn_gw_id": null,
 		"vrid": 1
 	}
 }`
 
 var GatewayInterface1 = gateway_interfaces.GatewayInterface{
 	Description:   "",
-	FICGatewayID:  "9c5c6441-e174-4b9a-9d16-4ed38cc95dd5",
 	GwVipv4:       "100.127.254.49",
 	ID:            "09771fbb-6496-4ae1-9b53-226b6edcc1be",
 	InternetGwID:  "e72ef35a-c96f-45f8-aeee-e7547c5b94b3",
@@ -171,27 +184,18 @@ var GatewayInterface1 = gateway_interfaces.GatewayInterface{
 }
 
 var GatewayInterface2 = gateway_interfaces.GatewayInterface{
-	AwsGwID:       "",
-	AzureGwID:     "",
-	Description:   "lab3-test-user-internet-gateway-interface, role : member",
+	Description:   "lab3-test-user-fic-gateway-interface, role : member",
 	FICGatewayID:  "dd04adc4-459f-4fc4-83a5-47436c6aece5",
-	GcpGwID:       "",
 	GwVipv4:       "100.127.254.1",
-	GwVipv6:       "",
 	ID:            "165ed64c-b9d4-46b1-afc1-cbbdc356ddcb",
-	InterdcGwID:   "",
-	InternetGwID:  "0ed09319-fe94-4618-8482-23ee254f3d2c",
 	Name:          "lab3-hara-cfg-20151204",
 	Netmask:       29,
 	NetworkID:     "cce5c9a1-1ec3-40b1-bfc7-634bb914646b",
 	PrimaryIpv4:   "100.127.254.3",
-	PrimaryIpv6:   "",
 	SecondaryIpv4: "100.127.254.4",
-	SecondaryIpv6: "",
-	ServiceType:   "internet",
+	ServiceType:   "fic",
 	Status:        "ACTIVE",
 	TenantID:      "fe1f6fb95b0e48ba8c59be2121a58adc",
-	VpnGwID:       "",
 	VRID:          10,
 }
 

--- a/ecl/network/v2/gateway_interfaces/testing/request_test.go
+++ b/ecl/network/v2/gateway_interfaces/testing/request_test.go
@@ -88,7 +88,6 @@ func TestCreateGatewayInterface(t *testing.T) {
 
 	options := gateway_interfaces.CreateOpts{
 		Description:   "",
-		FICGatewayID:  "9c5c6441-e174-4b9a-9d16-4ed38cc95dd5",
 		GwVipv4:       "100.127.254.49",
 		InternetGwID:  "e72ef35a-c96f-45f8-aeee-e7547c5b94b3",
 		Name:          "5_Gateway",
@@ -97,13 +96,10 @@ func TestCreateGatewayInterface(t *testing.T) {
 		PrimaryIpv4:   "100.127.254.53",
 		SecondaryIpv4: "100.127.254.54",
 		ServiceType:   "internet",
-		TenantID:      "19ab165c7a664abe9c217334cd0e9cc9",
 		VRID:          1,
 	}
 	i, err := gateway_interfaces.Create(fake.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
-
-	th.AssertEquals(t, i.Status, "PENDING_CREATE")
 	th.AssertDeepEquals(t, &GatewayInterface1, i)
 }
 
@@ -125,7 +121,7 @@ func TestUpdateGatewayInterface(t *testing.T) {
 	})
 
 	description := "Updated"
-	name := "5_Gateway"
+	name := "6_Gateway"
 	options := gateway_interfaces.UpdateOpts{
 		Description: &description,
 		Name:        &name,
@@ -133,7 +129,7 @@ func TestUpdateGatewayInterface(t *testing.T) {
 	i, err := gateway_interfaces.Update(fake.ServiceClient(), "09771fbb-6496-4ae1-9b53-226b6edcc1be", options).Extract()
 	th.AssertNoErr(t, err)
 
-	th.AssertEquals(t, i.Name, "5_Gateway")
+	th.AssertEquals(t, i.Name, "6_Gateway")
 	th.AssertEquals(t, i.Description, "Updated")
 	th.AssertEquals(t, i.ID, "09771fbb-6496-4ae1-9b53-226b6edcc1be")
 }


### PR DESCRIPTION
* Createパラメータの`fic_gw_id`を`omitempty`にした
* 不要なCreateパラメータ(`gw_vipv6`など)を削除した
* サービスID(`fic_gw_id`, `internet_gw_id`など)は同時に1つしか指定できないので、仕様に併せてテストケースを修正した