### PR TITLE
Add idle_timeout to Policy of Managed Load Balancer

### DIFF
--- a/v2/ecl/managed_load_balancer/v1/certificates/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/certificates/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - ID of the owner tenant of the resource
@@ -77,13 +79,17 @@ Create Certificate
 type CreateOpts struct {
 
 	// - Name of the certificate
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the certificate
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the certificate
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -134,13 +140,17 @@ Update Certificate
 type UpdateOpts struct {
 
 	// - Name of the certificate
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the certificate
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the certificate
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -195,9 +205,9 @@ type UploadFileOpts struct {
 	Type string `json:"type"`
 
 	// - Content of the certificate file to be uploaded
-	// - Size of the file before encoding by Base64 must be less than or equal to 16KB
-	// - Must be specified the content of the file that encoded by Base64 format
-	//   - Format of the file before encoding by Base64 must be PEM
+	// - Content must be Base64 encoded
+	//   - The file size before encoding must be less than or equal to 16KB
+	//   - The file format before encoding must be PEM
 	//   - DER can be converted to PEM by using OpenSSL command
 	Content string `json:"content"`
 }

--- a/v2/ecl/managed_load_balancer/v1/health_monitors/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/health_monitors/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -100,17 +102,21 @@ Create Health Monitor
 type CreateOpts struct {
 
 	// - Name of the health monitor
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the health monitor
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the health monitor
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - Port number of the health monitor for healthchecking
-	// - Must be specified `0` when `protocol` is `"icmp"`
+	// - If 'protocol' is 'icmp', value must be set `0`
 	Port int `json:"port"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -121,20 +127,22 @@ type CreateOpts struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
-	// - Must be specified a number less than or equal to `interval`
+	// - Value must be less than or equal to `interval`
 	Timeout int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Can be specified path to monitor when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, URL path can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, URL path must not be set
 	// - Must be started with /
 	Path string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Can be specified HTTP status code (or range) when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, HTTP status code (or range) can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, HTTP status code (or range) must not be set
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode string `json:"http_status_code,omitempty"`
 
@@ -175,7 +183,7 @@ Show Health Monitor
 // ShowOpts represents options used to show a health monitor.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -215,13 +223,17 @@ Update Health Monitor Attributes
 type UpdateOpts struct {
 
 	// - Name of the health monitor
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the health monitor
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the health monitor
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -272,7 +284,7 @@ Create Staged Health Monitor Configurations
 type CreateStagedOpts struct {
 
 	// - Port number of the health monitor for healthchecking
-	// - Must be specified `0` when `protocol` is `"icmp"`
+	// - If 'protocol' is 'icmp', value must be set `0`
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -283,20 +295,22 @@ type CreateStagedOpts struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
-	// - Must be specified a number less than or equal to `interval`
+	// - Value must be less than or equal to `interval`
 	Timeout int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Can be specified path to monitor when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, URL path can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, URL path must not be set
 	// - Must be started with /
 	Path string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Can be specified HTTP status code (or range) when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, HTTP status code (or range) can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, HTTP status code (or range) must not be set
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode string `json:"http_status_code,omitempty"`
 }
@@ -348,7 +362,7 @@ Update Staged Health Monitor Configurations
 type UpdateStagedOpts struct {
 
 	// - Port number of the health monitor for healthchecking
-	// - Must be specified `0` when `protocol` is `"icmp"`
+	// - If 'protocol' is 'icmp', value must be set `0`
 	Port *int `json:"port,omitempty"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -359,20 +373,22 @@ type UpdateStagedOpts struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry *int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
-	// - Must be specified a number less than or equal to `interval`
+	// - Value must be less than or equal to `interval`
 	Timeout *int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Can be specified path to monitor when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, URL path can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, URL path must not be set
 	// - Must be started with /
 	Path *string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Can be specified HTTP status code (or range) when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, HTTP status code (or range) can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, HTTP status code (or range) must not be set
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode *string `json:"http_status_code,omitempty"`
 }

--- a/v2/ecl/managed_load_balancer/v1/health_monitors/results.go
+++ b/v2/ecl/managed_load_balancer/v1/health_monitors/results.go
@@ -64,7 +64,7 @@ type CancelStagedResult struct {
 type ConfigurationInResponse struct {
 
 	// - Port number of the health monitor for healthchecking
-	// - Returns `0` when `protocol` is `"icmp"`
+	// - If `protocol` is `"icmp"`, returns `0`
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -75,18 +75,18 @@ type ConfigurationInResponse struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
 	Timeout int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Used when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, uses this parameter
 	Path string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Used when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, uses this parameter
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode string `json:"http_status_code,omitempty"`
 }
@@ -144,7 +144,7 @@ type HealthMonitor struct {
 	TenantID string `json:"tenant_id"`
 
 	// - Port number of the health monitor for healthchecking
-	// - Returns `0` when `protocol` is `"icmp"`
+	// - If `protocol` is `"icmp"`, returns `0`
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -155,29 +155,29 @@ type HealthMonitor struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
 	Timeout int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Used when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, uses this parameter
 	Path string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Used when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, uses this parameter
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode string `json:"http_status_code,omitempty"`
 
 	// - Running configurations of the health monitor
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the health monitor that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/listeners/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/listeners/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -86,22 +88,27 @@ Create Listener
 type CreateOpts struct {
 
 	// - Name of the listener
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the listener
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the listener
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - IP address of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
-	// - Must be specified the ip address which is not included in subnet of load balancer interfaces that the listener belongs to
+	// - Set an unique combination of IP address and port in all listeners which belong to the same load balancer
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the listener belongs to
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 
 	// - Port number of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
+	// - Combination of IP address and port must be unique for all listeners which belong to the same load balancer
 	Port int `json:"port"`
 
 	// - Protocol of the listener for listening
@@ -144,7 +151,7 @@ Show Listener
 // ShowOpts represents options used to show a listener.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -184,13 +191,17 @@ Update Listener Attribute
 type UpdateOpts struct {
 
 	// - Name of the listener
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the listener
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the listener
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -241,12 +252,13 @@ Create Staged Listener Configurations
 type CreateStagedOpts struct {
 
 	// - IP address of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
-	// - Must be specified the ip address which is not included in subnet of load balancer interfaces that the listener belongs to
+	// - Set an unique combination of IP address and port in all listeners which belong to the same load balancer
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the listener belongs to
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address,omitempty"`
 
 	// - Port number of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
+	// - Combination of IP address and port must be unique for all listeners which belong to the same load balancer
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the listener for listening
@@ -300,12 +312,13 @@ Update Staged Listener Configurations
 type UpdateStagedOpts struct {
 
 	// - IP address of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
-	// - Must be specified the ip address which is not included in subnet of load balancer interfaces that the listener belongs to
+	// - Set an unique combination of IP address and port in all listeners which belong to the same load balancer
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the listener belongs to
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress *string `json:"ip_address,omitempty"`
 
 	// - Port number of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
+	// - Combination of IP address and port must be unique for all listeners which belong to the same load balancer
 	Port *int `json:"port,omitempty"`
 
 	// - Protocol of the listener for listening

--- a/v2/ecl/managed_load_balancer/v1/listeners/results.go
+++ b/v2/ecl/managed_load_balancer/v1/listeners/results.go
@@ -135,13 +135,13 @@ type Listener struct {
 	Protocol string `json:"protocol,omitempty"`
 
 	// - Running configurations of the listener
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the listener that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/load_balancers/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/load_balancers/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -93,8 +95,9 @@ type CreateOptsReservedFixedIP struct {
 
 	// - The IP address assign to this interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 }
 
@@ -102,20 +105,19 @@ type CreateOptsReservedFixedIP struct {
 type CreateOptsInterface struct {
 
 	// - ID of the network that this interface belongs to
-	// - Must be specified the unique network ID in `interfaces`
-	// - Must be specified the network that plane is data
-	// - Must not be specified the network that uses ISP shared address (RFC 6598)
+	// - Set a unique network ID in `interfaces`
+	// - Set a network of which plane is data
+	// - Must not set ID of a network that uses ISP shared address (RFC 6598)
 	NetworkID string `json:"network_id"`
 
 	// - Virtual IP address of the interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
-	// - Must not be specified for existing interfaces
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Set a network IP address and broadcast IP address
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	VirtualIPAddress string `json:"virtual_ip_address"`
 
 	// - IP addresses that are pre-reserved for applying configurations of load balancer to be performed without losing redundancy
-	// - Must not be specified for existing interfaces
 	ReservedFixedIPs *[]CreateOptsReservedFixedIP `json:"reserved_fixed_ips"`
 }
 
@@ -130,7 +132,7 @@ type CreateOptsSyslogServer struct {
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the syslog server
-	// - Must be specified same protocol in all syslog servers belongs to the same load balancer
+	// - Set same protocol in all syslog servers which belong to the same load balancer
 	Protocol string `json:"protocol,omitempty"`
 }
 
@@ -138,25 +140,30 @@ type CreateOptsSyslogServer struct {
 type CreateOpts struct {
 
 	// - Name of the load balancer
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the load balancer
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the load balancer
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - ID of the plan
 	PlanID string `json:"plan_id,omitempty"`
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers *[]CreateOptsSyslogServer `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer
@@ -198,7 +205,7 @@ Show Load Balancer
 // ShowOpts represents options used to show a load balancer.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -238,13 +245,17 @@ Update Load Balancer Attributes
 type UpdateOpts struct {
 
 	// - Name of the load balancer
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the load balancer
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the load balancer
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -353,8 +364,9 @@ type CreateStagedOptsReservedFixedIP struct {
 
 	// - The IP address assign to this interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 }
 
@@ -362,20 +374,21 @@ type CreateStagedOptsReservedFixedIP struct {
 type CreateStagedOptsInterface struct {
 
 	// - ID of the network that this interface belongs to
-	// - Must be specified the unique network ID in `interfaces`
-	// - Must be specified the network that plane is data
-	// - Must not be specified the network that uses ISP shared address (RFC 6598)
+	// - Set a unique network ID in `interfaces`
+	// - Set a network of which plane is data
+	// - Must not set ID of a network that uses ISP shared address (RFC 6598)
 	NetworkID string `json:"network_id"`
 
 	// - Virtual IP address of the interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
-	// - Must not be specified for existing interfaces
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - If there are no changes to the `network_id` within the `interfaces[]` , set the current `virtual_ip_address` value
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	VirtualIPAddress string `json:"virtual_ip_address"`
 
 	// - IP addresses that are pre-reserved for applying configurations of load balancer to be performed without losing redundancy
-	// - Must not be specified for existing interfaces
+	// - If there are no changes to the `network_id` within the `interfaces[]` , set the current `reserved_fixed_ips` value
 	ReservedFixedIPs *[]CreateStagedOptsReservedFixedIP `json:"reserved_fixed_ips"`
 }
 
@@ -390,7 +403,7 @@ type CreateStagedOptsSyslogServer struct {
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the syslog server
-	// - Must be specified same protocol in all syslog servers belongs to the same load balancer
+	// - Set same protocol in all syslog servers which belong to the same load balancer
 	Protocol string `json:"protocol,omitempty"`
 }
 
@@ -398,12 +411,13 @@ type CreateStagedOptsSyslogServer struct {
 type CreateStagedOpts struct {
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers *[]CreateStagedOptsSyslogServer `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer
@@ -460,8 +474,9 @@ type UpdateStagedOptsReservedFixedIP struct {
 
 	// - The IP address assign to this interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress *string `json:"ip_address"`
 }
 
@@ -469,20 +484,21 @@ type UpdateStagedOptsReservedFixedIP struct {
 type UpdateStagedOptsInterface struct {
 
 	// - ID of the network that this interface belongs to
-	// - Must be specified the unique network ID in `interfaces`
-	// - Must be specified the network that plane is data
-	// - Must not be specified the network that uses ISP shared address (RFC 6598)
+	// - Set a unique network ID in `interfaces`
+	// - Set a network of which plane is data
+	// - Must not set ID of a network that uses ISP shared address (RFC 6598)
 	NetworkID *string `json:"network_id"`
 
 	// - Virtual IP address of the interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
-	// - Must not be specified for existing interfaces
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - If there are no changes to the `network_id` within the `interfaces[]` , set the current `virtual_ip_address` value
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	VirtualIPAddress *string `json:"virtual_ip_address"`
 
 	// - IP addresses that are pre-reserved for applying configurations of load balancer to be performed without losing redundancy
-	// - Must not be specified for existing interfaces
+	// - If there are no changes to the `network_id` within the `interfaces[]` , set the current `reserved_fixed_ips` value
 	ReservedFixedIPs *[]UpdateStagedOptsReservedFixedIP `json:"reserved_fixed_ips"`
 }
 
@@ -497,7 +513,7 @@ type UpdateStagedOptsSyslogServer struct {
 	Port *int `json:"port,omitempty"`
 
 	// - Protocol of the syslog server
-	// - Must be specified same protocol in all syslog servers belongs to the same load balancer
+	// - Set same protocol in all syslog servers which belong to the same load balancer
 	Protocol *string `json:"protocol,omitempty"`
 }
 
@@ -505,12 +521,13 @@ type UpdateStagedOptsSyslogServer struct {
 type UpdateStagedOpts struct {
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers *[]UpdateStagedOptsSyslogServer `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer

--- a/v2/ecl/managed_load_balancer/v1/load_balancers/results.go
+++ b/v2/ecl/managed_load_balancer/v1/load_balancers/results.go
@@ -78,12 +78,13 @@ type ReservedFixedIPInResponse struct {
 type ConfigurationInResponse struct {
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers []SyslogServerInResponse `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer
@@ -178,7 +179,7 @@ type LoadBalancer struct {
 	SecondaryAvailabilityZone string `json:"secondary_availability_zone,omitempty"`
 
 	// - Primary or secondary availability zone where the load balancer is currently running
-	// - Return `"UNDEFINED"` if can not define active availability zone
+	// - If can not define active availability zone, returns `"UNDEFINED"`
 	ActiveAvailabilityZone string `json:"active_availability_zone"`
 
 	// - Revision of the load balancer
@@ -194,25 +195,26 @@ type LoadBalancer struct {
 	TenantID string `json:"tenant_id"`
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers []SyslogServerInResponse `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer
 	Interfaces []InterfaceInResponse `json:"interfaces,omitempty"`
 
 	// - Running configurations of the load balancer
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the load balancer that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/operations/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/operations/requests.go
@@ -38,10 +38,10 @@ type ListOpts struct {
 	// - ID of the owner tenant of the resource
 	TenantID string `q:"tenant_id"`
 
-	// - When `true` is specified, operations of deleted resource is not displayed
+	// - If `true` is set, operations of deleted resource is not displayed
 	NoDeleted bool `q:"no_deleted"`
 
-	// - When `true` is specified, only the latest operation of each resource is displayed
+	// - If `true` is set, only the latest operation of each resource is displayed
 	Latest bool `q:"latest"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/plans/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/plans/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Bandwidth of the plan

--- a/v2/ecl/managed_load_balancer/v1/policies/doc.go
+++ b/v2/ecl/managed_load_balancer/v1/policies/doc.go
@@ -37,6 +37,7 @@ Example to create a policy
 		Tags: tags,
 		Algorithm: "round-robin",
 		Persistence: "cookie",
+		IdleTimeout: 600,
 		SorryPageUrl: "https://example.com/sorry",
 		SourceNat: "enable",
 		CertificateID: "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -105,6 +106,7 @@ Example to create staged policy configurations
 	createStagedOpts := policies.CreateStagedOpts{
 		Algorithm: "round-robin",
 		Persistence: "cookie",
+		IdleTimeout: 600,
 		SorryPageUrl: "https://example.com/sorry",
 		SourceNat: "enable",
 		CertificateID: "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -136,6 +138,7 @@ Example to update staged policy configurations
 
 	algorithm := "round-robin"
 	persistence := "cookie"
+	idleTimeout := 600
 	sorryPageUrl := "https://example.com/sorry"
 	sourceNat := "enable"
 	certificateID := "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -146,6 +149,7 @@ Example to update staged policy configurations
 	updateStagedOpts := policies.UpdateStagedOpts{
 		Algorithm: &algorithm,
 		Persistence: &persistence,
+		IdleTimeout: &idleTimeout,
 		SorryPageUrl: &sorryPageUrl,
 		SourceNat: &sourceNat,
 		CertificateID: &certificateID,

--- a/v2/ecl/managed_load_balancer/v1/policies/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/policies/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -37,8 +39,7 @@ type ListOpts struct {
 	// - Persistence setting of the policy
 	Persistence string `q:"persistence"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Must be specified as URL format
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	SorryPageUrl string `q:"sorry_page_url"`
 
 	// - Source NAT setting of the policy
@@ -105,56 +106,60 @@ Create Policy
 type CreateOpts struct {
 
 	// - Name of the policy
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the policy
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the policy
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - Load balancing algorithm (method) of the policy
 	Algorithm string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Can be specified when `listener.protocol` is `"http"` or `"https"`
-	// - Must be specified as URL format
-	// - Must not be specified or be specified as `""` when `listener.protocol` is neither `"http"` nor `"https"`
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
+	// - If `listener.protocol` is neither `"http"` nor `"https"`, must not set this parameter or set `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"`
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Can be specified the certificate which `ca_cert.status` , `ssl_cert.status` and `ssl_key.status` is `"UPLOADED"`
-	// - Must be specified `certificate.id` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
+	// - You can set a ID of the certificate in which `ca_cert.status`, `ssl_cert.status` and `ssl_key.status` are all `"UPLOADED"`
+	// - If `listener.protocol` is `"https"`, set `certificate.id`
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
 	CertificateID string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
-	// - Must not be specified the ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
 	HealthMonitorID string `json:"health_monitor_id"`
 
 	// - ID of the listener that assigned to the policy
-	// - Must not be specified the ID of the listener that `configuration_status` is `"DELETE_STAGED"`
-	// - Must not be specified the ID of the listener that already assigned to the other policy
+	// - Must not set ID of the listener that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the listener that already assigned to the other policy
 	ListenerID string `json:"listener_id"`
 
 	// - ID of the default target group that assigned to the policy
-	// - Must not be specified the ID of the target group that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the target group that `configuration_status` is `"DELETE_STAGED"`
 	DefaultTargetGroupID string `json:"default_target_group_id"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Can be specified or will be set `tls_policy.id` which `default` is `true` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
+	// - If `listener.protocol` is `"https"`, you can set this parameter explicitly
+	//   - If not set this parameter, the ID of the `tls_policy` with `default: true` will be automatically set
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
 	TLSPolicyID string `json:"tls_policy_id,omitempty"`
 
 	// - ID of the load balancer which the policy belongs to
@@ -194,7 +199,7 @@ Show Policy
 // ShowOpts represents options used to show a policy.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -234,13 +239,17 @@ Update Policy Attributes
 type UpdateOpts struct {
 
 	// - Name of the policy
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the policy
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the policy
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -294,46 +303,46 @@ type CreateStagedOpts struct {
 	Algorithm string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Can be specified when `listener.protocol` is `"http"` or `"https"`
-	// - Must be specified as URL format
-	// - Must not be specified or be specified as `""` when `listener.protocol` is neither `"http"` nor `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"http"` or `"https"` to others
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
+	// - If `listener.protocol` is neither `"http"` nor `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"http"` or `"https"` to others, set `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"`
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Can be specified the certificate which `ca_cert.status` , `ssl_cert.status` and `ssl_key.status` is `"UPLOADED"`
-	// - Must be specified `certificate.id` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"https"` to others
+	// - You can set a ID of the certificate in which `ca_cert.status`, `ssl_cert.status` and `ssl_key.status` are all `"UPLOADED"`
+	// - If `listener.protocol` is `"https"`, set `certificate.id`
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"https"` to others, set `""`
 	CertificateID string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
-	// - Must not be specified the ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
 	HealthMonitorID string `json:"health_monitor_id,omitempty"`
 
 	// - ID of the listener that assigned to the policy
-	// - Must not be specified the ID of the listener that `configuration_status` is `"DELETE_STAGED"`
-	// - Must not be specified the ID of the listener that already assigned to the other policy
+	// - Must not set ID of the listener that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the listener that already assigned to the other policy
 	ListenerID string `json:"listener_id,omitempty"`
 
 	// - ID of the default target group that assigned to the policy
-	// - Must not be specified the ID of the target group that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the target group that `configuration_status` is `"DELETE_STAGED"`
 	DefaultTargetGroupID string `json:"default_target_group_id,omitempty"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Can be specified or will be set `tls_policy.id` which `default` is `true` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"https"` to others
+	// - If `listener.protocol` is `"https"`, you can set this parameter explicitly
+	//   - If not set this parameter, the ID of the `tls_policy` with `default: true` will be automatically set
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"https"` to others, set `""`
 	TLSPolicyID string `json:"tls_policy_id,omitempty"`
 }
 
@@ -387,46 +396,46 @@ type UpdateStagedOpts struct {
 	Algorithm *string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence *string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Can be specified when `listener.protocol` is `"http"` or `"https"`
-	// - Must be specified as URL format
-	// - Must not be specified or be specified as `""` when `listener.protocol` is neither `"http"` nor `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"http"` or `"https"` to others
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
+	// - If `listener.protocol` is neither `"http"` nor `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"http"` or `"https"` to others, set `""`
 	SorryPageUrl *string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"`
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat *string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Can be specified the certificate which `ca_cert.status` , `ssl_cert.status` and `ssl_key.status` is `"UPLOADED"`
-	// - Must be specified `certificate.id` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"https"` to others
+	// - You can set a ID of the certificate in which `ca_cert.status`, `ssl_cert.status` and `ssl_key.status` are all `"UPLOADED"`
+	// - If `listener.protocol` is `"https"`, set `certificate.id`
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"https"` to others, set `""`
 	CertificateID *string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
-	// - Must not be specified the ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
 	HealthMonitorID *string `json:"health_monitor_id,omitempty"`
 
 	// - ID of the listener that assigned to the policy
-	// - Must not be specified the ID of the listener that `configuration_status` is `"DELETE_STAGED"`
-	// - Must not be specified the ID of the listener that already assigned to the other policy
+	// - Must not set ID of the listener that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the listener that already assigned to the other policy
 	ListenerID *string `json:"listener_id,omitempty"`
 
 	// - ID of the default target group that assigned to the policy
-	// - Must not be specified the ID of the target group that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the target group that `configuration_status` is `"DELETE_STAGED"`
 	DefaultTargetGroupID *string `json:"default_target_group_id,omitempty"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Can be specified or will be set `tls_policy.id` which `default` is `true` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"https"` to others
+	// - If `listener.protocol` is `"https"`, you can set this parameter explicitly
+	//   - If not set this parameter, the ID of the `tls_policy` with `default: true` will be automatically set
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"https"` to others, set `""`
 	TLSPolicyID *string `json:"tls_policy_id,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/policies/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/policies/requests.go
@@ -39,6 +39,9 @@ type ListOpts struct {
 	// - Persistence setting of the policy
 	Persistence string `q:"persistence"`
 
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	IdleTimeout int `q:"idle_timeout"`
+
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	SorryPageUrl string `q:"sorry_page_url"`
 
@@ -125,6 +128,15 @@ type CreateOpts struct {
 	// - Persistence setting of the policy
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
+
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout int `json:"idle_timeout,omitempty"`
 
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
@@ -306,6 +318,15 @@ type CreateStagedOpts struct {
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout int `json:"idle_timeout,omitempty"`
+
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
 	// - If `listener.protocol` is neither `"http"` nor `"https"`, must not set this parameter or set `""`
@@ -398,6 +419,15 @@ type UpdateStagedOpts struct {
 	// - Persistence setting of the policy
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence *string `json:"persistence,omitempty"`
+
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout *int `json:"idle_timeout,omitempty"`
 
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set

--- a/v2/ecl/managed_load_balancer/v1/policies/results.go
+++ b/v2/ecl/managed_load_balancer/v1/policies/results.go
@@ -67,21 +67,21 @@ type ConfigurationInResponse struct {
 	Algorithm string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Returns `""` when protocol is not `"http"` or `"https"`
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If protocol is not `"http"` or `"https"`, returns `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Returns `""` when protocol is not `"https"`
+	// - If protocol is not `"https"`, returns `""`
 	CertificateID string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
@@ -94,7 +94,7 @@ type ConfigurationInResponse struct {
 	DefaultTargetGroupID string `json:"default_target_group_id,omitempty"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Returns `""` when protocol is not `"https"`
+	// - If protocol is not `"https"`, returns `""`
 	TLSPolicyID string `json:"tls_policy_id,omitempty"`
 }
 
@@ -154,21 +154,21 @@ type Policy struct {
 	Algorithm string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Returns `""` when protocol is not `"http"` or `"https"`
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If protocol is not `"http"` or `"https"`, returns `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Returns `""` when protocol is not `"https"`
+	// - If protocol is not `"https"`, returns `""`
 	CertificateID string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
@@ -181,17 +181,17 @@ type Policy struct {
 	DefaultTargetGroupID string `json:"default_target_group_id,omitempty"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Returns `""` when protocol is not `"https"`
+	// - If protocol is not `"https"`, returns `""`
 	TLSPolicyID string `json:"tls_policy_id,omitempty"`
 
 	// - Running configurations of the policy
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the policy that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/policies/results.go
+++ b/v2/ecl/managed_load_balancer/v1/policies/results.go
@@ -70,6 +70,15 @@ type ConfigurationInResponse struct {
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout int `json:"idle_timeout,omitempty"`
+
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If protocol is not `"http"` or `"https"`, returns `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
@@ -156,6 +165,15 @@ type Policy struct {
 	// - Persistence setting of the policy
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
+
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout int `json:"idle_timeout,omitempty"`
 
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If protocol is not `"http"` or `"https"`, returns `""`

--- a/v2/ecl/managed_load_balancer/v1/policies/testing/fixtures.go
+++ b/v2/ecl/managed_load_balancer/v1/policies/testing/fixtures.go
@@ -28,6 +28,7 @@ var listResponse = fmt.Sprintf(`
             "tenant_id": "34f5c98ef430457ba81292637d0c6fd0",
             "algorithm": "round-robin",
             "persistence": "cookie",
+            "idle_timeout": 600,
             "sorry_page_url": "https://example.com/sorry",
             "source_nat": "enable",
             "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -59,6 +60,7 @@ func listResult() []policies.Policy {
 	policy1.TenantID = "34f5c98ef430457ba81292637d0c6fd0"
 	policy1.Algorithm = "round-robin"
 	policy1.Persistence = "cookie"
+	policy1.IdleTimeout = 600
 	policy1.SorryPageUrl = "https://example.com/sorry"
 	policy1.SourceNat = "enable"
 	policy1.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -80,6 +82,7 @@ var createRequest = fmt.Sprintf(`
         },
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -106,6 +109,7 @@ var createResponse = fmt.Sprintf(`
         "tenant_id": "34f5c98ef430457ba81292637d0c6fd0",
         "algorithm": null,
         "persistence": null,
+        "idle_timeout": null,
         "sorry_page_url": null,
         "source_nat": null,
         "certificate_id": null,
@@ -136,6 +140,7 @@ func createResult() *policies.Policy {
 	policy.TenantID = "34f5c98ef430457ba81292637d0c6fd0"
 	policy.Algorithm = ""
 	policy.Persistence = ""
+	policy.IdleTimeout = 0
 	policy.SorryPageUrl = ""
 	policy.SourceNat = ""
 	policy.CertificateID = ""
@@ -162,6 +167,7 @@ var showResponse = fmt.Sprintf(`
         "tenant_id": "34f5c98ef430457ba81292637d0c6fd0",
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -172,6 +178,7 @@ var showResponse = fmt.Sprintf(`
         "current": {
             "algorithm": "round-robin",
             "persistence": "cookie",
+            "idle_timeout": 600,
             "sorry_page_url": "https://example.com/sorry",
             "source_nat": "enable",
             "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -191,6 +198,7 @@ func showResult() *policies.Policy {
 	current := policies.ConfigurationInResponse{
 		Algorithm:            "round-robin",
 		Persistence:          "cookie",
+		IdleTimeout:          600,
 		SorryPageUrl:         "https://example.com/sorry",
 		SourceNat:            "enable",
 		CertificateID:        "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -217,6 +225,7 @@ func showResult() *policies.Policy {
 	policy.TenantID = "34f5c98ef430457ba81292637d0c6fd0"
 	policy.Algorithm = "round-robin"
 	policy.Persistence = "cookie"
+	policy.IdleTimeout = 600
 	policy.SorryPageUrl = "https://example.com/sorry"
 	policy.SourceNat = "enable"
 	policy.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -256,6 +265,7 @@ var updateResponse = fmt.Sprintf(`
         "tenant_id": "34f5c98ef430457ba81292637d0c6fd0",
         "algorithm": null,
         "persistence": null,
+        "idle_timeout": null,
         "sorry_page_url": null,
         "source_nat": null,
         "certificate_id": null,
@@ -286,6 +296,7 @@ func updateResult() *policies.Policy {
 	policy.TenantID = "34f5c98ef430457ba81292637d0c6fd0"
 	policy.Algorithm = ""
 	policy.Persistence = ""
+	policy.IdleTimeout = 0
 	policy.SorryPageUrl = ""
 	policy.SourceNat = ""
 	policy.CertificateID = ""
@@ -302,6 +313,7 @@ var createStagedRequest = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -317,6 +329,7 @@ var createStagedResponse = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -332,6 +345,7 @@ func createStagedResult() *policies.Policy {
 
 	policy.Algorithm = "round-robin"
 	policy.Persistence = "cookie"
+	policy.IdleTimeout = 600
 	policy.SorryPageUrl = "https://example.com/sorry"
 	policy.SourceNat = "enable"
 	policy.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -348,6 +362,7 @@ var showStagedResponse = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -363,6 +378,7 @@ func showStagedResult() *policies.Policy {
 
 	policy.Algorithm = "round-robin"
 	policy.Persistence = "cookie"
+	policy.IdleTimeout = 600
 	policy.SorryPageUrl = "https://example.com/sorry"
 	policy.SourceNat = "enable"
 	policy.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -379,6 +395,7 @@ var updateStagedRequest = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -394,6 +411,7 @@ var updateStagedResponse = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -409,6 +427,7 @@ func updateStagedResult() *policies.Policy {
 
 	policy.Algorithm = "round-robin"
 	policy.Persistence = "cookie"
+	policy.IdleTimeout = 600
 	policy.SorryPageUrl = "https://example.com/sorry"
 	policy.SourceNat = "enable"
 	policy.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"

--- a/v2/ecl/managed_load_balancer/v1/policies/testing/requests_test.go
+++ b/v2/ecl/managed_load_balancer/v1/policies/testing/requests_test.go
@@ -97,6 +97,7 @@ func TestCreatePolicy(t *testing.T) {
 		Tags:                 tags,
 		Algorithm:            "round-robin",
 		Persistence:          "cookie",
+		IdleTimeout:          600,
 		SorryPageUrl:         "https://example.com/sorry",
 		SourceNat:            "enable",
 		CertificateID:        "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -223,6 +224,7 @@ func TestCreateStagedPolicy(t *testing.T) {
 	createStagedOpts := policies.CreateStagedOpts{
 		Algorithm:            "round-robin",
 		Persistence:          "cookie",
+		IdleTimeout:          600,
 		SorryPageUrl:         "https://example.com/sorry",
 		SourceNat:            "enable",
 		CertificateID:        "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -284,6 +286,7 @@ func TestUpdateStagedPolicy(t *testing.T) {
 
 	algorithm := "round-robin"
 	persistence := "cookie"
+	idleTimeout := 600
 	sorryPageUrl := "https://example.com/sorry"
 	sourceNat := "enable"
 	certificateID := "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -294,6 +297,7 @@ func TestUpdateStagedPolicy(t *testing.T) {
 	updateStagedOpts := policies.UpdateStagedOpts{
 		Algorithm:            &algorithm,
 		Persistence:          &persistence,
+		IdleTimeout:          &idleTimeout,
 		SorryPageUrl:         &sorryPageUrl,
 		SourceNat:            &sourceNat,
 		CertificateID:        &certificateID,

--- a/v2/ecl/managed_load_balancer/v1/routes/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/routes/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -83,26 +85,31 @@ Create Route
 type CreateOpts struct {
 
 	// - Name of the (static) route
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the (static) route
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the (static) route
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - CIDR of destination for the (static) route
-	// - Can be specified as `0.0.0.0/0` to configure default gateway
+	// - If you configure `destination_cidr` as default gateway, set `0.0.0.0/0`
 	// - `destination_cidr` can not be changed once configured
-	//   - To change `destination_cidr` , recreating the (static) route is needed
-	// - Must be specified the unique CIDR in all (static) routes belongs to the same load balancer
-	// - Must be specified the CIDR which is not included in subnet of load balancer interfaces that the (static) route belongs to
+	//   - If you want to change `destination_cidr`, recreate the (static) route again
+	// - Set a unique CIDR for all (static) routes which belong to the same load balancer
+	// - Set a CIDR which is not included in subnet of load balancer interfaces that the (static) route belongs to
+	// - Must not set a link-local CIDR (RFC 3927) which includes Common Function Gateway
 	DestinationCidr string `json:"destination_cidr"`
 
 	// - ID of the load balancer which the (static) route belongs to
-	// - Must be specified the CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set a CIDR which is not included in subnet of load balancer interfaces that the (static) route belongs to
+	// - Must not set a network IP address and broadcast IP address
 	NextHopIPAddress string `json:"next_hop_ip_address"`
 
 	// - ID of the load balancer which the (static) route belongs to
@@ -142,7 +149,7 @@ Show Route
 // ShowOpts represents options used to show a route.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -182,13 +189,17 @@ Update Route Attributes
 type UpdateOpts struct {
 
 	// - Name of the (static) route
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the (static) route
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the (static) route
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -239,8 +250,8 @@ Create Staged Route Configurations
 type CreateStagedOpts struct {
 
 	// - ID of the load balancer which the (static) route belongs to
-	// - Must be specified the CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set a CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
+	// - Must not set a network IP address and broadcast IP address
 	NextHopIPAddress string `json:"next_hop_ip_address,omitempty"`
 }
 
@@ -291,8 +302,8 @@ Update Staged Route Configurations
 type UpdateStagedOpts struct {
 
 	// - ID of the load balancer which the (static) route belongs to
-	// - Must be specified the CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set a CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
+	// - Must not set a network IP address and broadcast IP address
 	NextHopIPAddress *string `json:"next_hop_ip_address,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/routes/results.go
+++ b/v2/ecl/managed_load_balancer/v1/routes/results.go
@@ -126,13 +126,13 @@ type Route struct {
 	NextHopIPAddress string `json:"next_hop_ip_address,omitempty"`
 
 	// - Running configurations of the (static) route
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the (static) route that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/rules/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/rules/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -86,8 +88,8 @@ Create Rule
 type CreateOptsCondition struct {
 
 	// - URL path patterns (regular expressions) of the condition
-	// - Must be specified the unique string in all path patterns belongs to the same policy
-	// - Must be specified as PCRE (Perl Compatible Regular Expressions) format
+	// - Set a path pattern as unique string in all path patterns which belong to the same policy
+	// - Set a path pattern in PCRE (Perl Compatible Regular Expressions) format
 	//   - Capturing groups and backreferences are not supported
 	PathPatterns []string `json:"path_patterns,omitempty"`
 }
@@ -96,29 +98,33 @@ type CreateOptsCondition struct {
 type CreateOpts struct {
 
 	// - Name of the rule
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the rule
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the rule
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - Priority of the rule
-	// - Must be specified the unique number in all rules belongs to the same policy
+	// - Set an unique number in all rules which belong to the same policy
 	Priority int `json:"priority,omitempty"`
 
 	// - ID of the target group that assigned to the rule
-	// - Must be specified the different target group from `"default_target_group_id"` of the policy
+	// - Set a different target group from `"default_target_group_id"` of the policy
 	TargetGroupID string `json:"target_group_id,omitempty"`
 
 	// - ID of the policy which the rule belongs to
-	// - Must be specified a policy which has a listener of which protocol is either `"http"` or `"https"`
+	// - Set ID of the policy which has a listener in which protocol is either `"http"` or `"https"`
 	PolicyID string `json:"policy_id,omitempty"`
 
 	// - Conditions of the rules to distribute accesses to the target groups
-	// - Must be specified one or more condition
+	// - Set one or more condition
 	Conditions *CreateOptsCondition `json:"conditions,omitempty"`
 }
 
@@ -155,7 +161,7 @@ Show Rule
 // ShowOpts represents options used to show a rule.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -195,13 +201,17 @@ Update Rule Attributes
 type UpdateOpts struct {
 
 	// - Name of the rule
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the rule
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the rule
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -252,8 +262,8 @@ Create Staged Rule Configurations
 type CreateStagedOptsCondition struct {
 
 	// - URL path patterns (regular expressions) of the condition
-	// - Must be specified the unique string in all path patterns belongs to the same policy
-	// - Must be specified as PCRE (Perl Compatible Regular Expressions) format
+	// - Set a path pattern as unique string in all path patterns which belong to the same policy
+	// - Set a path pattern in PCRE (Perl Compatible Regular Expressions) format
 	//   - Capturing groups and backreferences are not supported
 	PathPatterns []string `json:"path_patterns,omitempty"`
 }
@@ -262,15 +272,15 @@ type CreateStagedOptsCondition struct {
 type CreateStagedOpts struct {
 
 	// - Priority of the rule
-	// - Must be specified the unique number in all rules belongs to the same policy
+	// - Set an unique number in all rules which belong to the same policy
 	Priority int `json:"priority,omitempty"`
 
 	// - ID of the target group that assigned to the rule
-	// - Must be specified the different target group from `"default_target_group_id"` of the policy
+	// - Set a different target group from `"default_target_group_id"` of the policy
 	TargetGroupID string `json:"target_group_id,omitempty"`
 
 	// - Conditions of the rules to distribute accesses to the target groups
-	// - Must be specified one or more condition
+	// - Set one or more condition
 	Conditions *CreateStagedOptsCondition `json:"conditions,omitempty"`
 }
 
@@ -321,8 +331,8 @@ Update Staged Rule Configurations
 type UpdateStagedOptsCondition struct {
 
 	// - URL path patterns (regular expressions) of the condition
-	// - Must be specified the unique string in all path patterns belongs to the same policy
-	// - Must be specified as PCRE (Perl Compatible Regular Expressions) format
+	// - Set a path pattern as unique string in all path patterns which belong to the same policy
+	// - Set a path pattern in PCRE (Perl Compatible Regular Expressions) format
 	//   - Capturing groups and backreferences are not supported
 	PathPatterns *[]string `json:"path_patterns,omitempty"`
 }
@@ -331,15 +341,15 @@ type UpdateStagedOptsCondition struct {
 type UpdateStagedOpts struct {
 
 	// - Priority of the rule
-	// - Must be specified the unique number in all rules belongs to the same policy
+	// - Set an unique number in all rules which belong to the same policy
 	Priority *int `json:"priority,omitempty"`
 
 	// - ID of the target group that assigned to the rule
-	// - Must be specified the different target group from `"default_target_group_id"` of the policy
+	// - Set a different target group from `"default_target_group_id"` of the policy
 	TargetGroupID *string `json:"target_group_id,omitempty"`
 
 	// - Conditions of the rules to distribute accesses to the target groups
-	// - Must be specified one or more condition
+	// - Set one or more condition
 	Conditions *UpdateStagedOptsCondition `json:"conditions,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/rules/results.go
+++ b/v2/ecl/managed_load_balancer/v1/rules/results.go
@@ -145,13 +145,13 @@ type Rule struct {
 	Conditions ConditionInResponse `json:"conditions,omitempty"`
 
 	// - Running configurations of the rule
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the rule that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/system_updates/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/system_updates/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - URL of announcement for the system update (for example, Knowledge Center news)
@@ -37,7 +39,7 @@ type ListOpts struct {
 	// - Whether the system update can be applied to the load balancer
 	Applicable bool `q:"applicable"`
 
-	// - When `true` is specified, only the latest resource is displayed
+	// - If `true` is set, only the latest resource is displayed
 	Latest bool `q:"latest"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/target_groups/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/target_groups/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -77,16 +79,19 @@ Create Target Group
 type CreateOptsMember struct {
 
 	// - IP address of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the target group belongs to
+	// - Must not set a IP address of listeners which belong to the same load balancer as the target group
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 
 	// - Port number of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
 	Port int `json:"port"`
 
 	// - Weight for the member (real server)
-	// - Used when `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`
-	// - Must be specified same weight for the combination of ip address and port in all members belongs to the same load balancer
+	// - If `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`, use this parameter
+	// - Set same weight for the combination of IP address and port in all members which belong to the same load balancer
 	Weight int `json:"weight,omitempty"`
 }
 
@@ -94,13 +99,17 @@ type CreateOptsMember struct {
 type CreateOpts struct {
 
 	// - Name of the target group
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the target group
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the target group
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - ID of the load balancer which the target group belongs to
@@ -143,7 +152,7 @@ Show Target Group
 // ShowOpts represents options used to show a target group.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -183,13 +192,17 @@ Update Target Group Attributes
 type UpdateOpts struct {
 
 	// - Name of the target group
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the target group
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the target group
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -240,16 +253,19 @@ Create Staged Target Group Configurations
 type CreateStagedOptsMember struct {
 
 	// - IP address of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the target group belongs to
+	// - Must not set a IP address of listeners which belong to the same load balancer as the target group
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 
 	// - Port number of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
 	Port int `json:"port"`
 
 	// - Weight for the member (real server)
-	// - Used when `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`
-	// - Must be specified same weight for the combination of ip address and port in all members belongs to the same load balancer
+	// - If `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`, use this parameter
+	// - Set same weight for the combination of IP address and port in all members which belong to the same load balancer
 	Weight int `json:"weight,omitempty"`
 }
 
@@ -307,16 +323,19 @@ Update Staged Target Group Configurations
 type UpdateStagedOptsMember struct {
 
 	// - IP address of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the target group belongs to
+	// - Must not set a IP address of listeners which belong to the same load balancer as the target group
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress *string `json:"ip_address"`
 
 	// - Port number of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
 	Port *int `json:"port"`
 
 	// - Weight for the member (real server)
-	// - Used when `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`
-	// - Must be specified same weight for the combination of ip address and port in all members belongs to the same load balancer
+	// - If `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`, use this parameter
+	// - Set same weight for the combination of IP address and port in all members which belong to the same load balancer
 	Weight *int `json:"weight,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/target_groups/results.go
+++ b/v2/ecl/managed_load_balancer/v1/target_groups/results.go
@@ -77,7 +77,7 @@ type MemberInResponse struct {
 	Port int `json:"port"`
 
 	// - Weight for the member (real server)
-	// - Used when `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`
+	// - If `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`, uses this parameter
 	Weight int `json:"weight"`
 }
 
@@ -137,13 +137,13 @@ type TargetGroup struct {
 	Members []MemberInResponse `json:"members,omitempty"`
 
 	// - Running configurations of the target group
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the target group that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v2/ecl/managed_load_balancer/v1/tls_policies/requests.go
+++ b/v2/ecl/managed_load_balancer/v1/tls_policies/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Whether the TLS policy will be set `policy.tls_policy_id` when that is not specified

--- a/v3/ecl/managed_load_balancer/v1/certificates/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/certificates/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - ID of the owner tenant of the resource
@@ -77,13 +79,17 @@ Create Certificate
 type CreateOpts struct {
 
 	// - Name of the certificate
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the certificate
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the certificate
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -134,13 +140,17 @@ Update Certificate
 type UpdateOpts struct {
 
 	// - Name of the certificate
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the certificate
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the certificate
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -195,9 +205,9 @@ type UploadFileOpts struct {
 	Type string `json:"type"`
 
 	// - Content of the certificate file to be uploaded
-	// - Size of the file before encoding by Base64 must be less than or equal to 16KB
-	// - Must be specified the content of the file that encoded by Base64 format
-	//   - Format of the file before encoding by Base64 must be PEM
+	// - Content must be Base64 encoded
+	//   - The file size before encoding must be less than or equal to 16KB
+	//   - The file format before encoding must be PEM
 	//   - DER can be converted to PEM by using OpenSSL command
 	Content string `json:"content"`
 }

--- a/v3/ecl/managed_load_balancer/v1/health_monitors/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/health_monitors/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -100,17 +102,21 @@ Create Health Monitor
 type CreateOpts struct {
 
 	// - Name of the health monitor
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the health monitor
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the health monitor
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - Port number of the health monitor for healthchecking
-	// - Must be specified `0` when `protocol` is `"icmp"`
+	// - If 'protocol' is 'icmp', value must be set `0`
 	Port int `json:"port"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -121,20 +127,22 @@ type CreateOpts struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
-	// - Must be specified a number less than or equal to `interval`
+	// - Value must be less than or equal to `interval`
 	Timeout int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Can be specified path to monitor when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, URL path can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, URL path must not be set
 	// - Must be started with /
 	Path string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Can be specified HTTP status code (or range) when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, HTTP status code (or range) can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, HTTP status code (or range) must not be set
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode string `json:"http_status_code,omitempty"`
 
@@ -175,7 +183,7 @@ Show Health Monitor
 // ShowOpts represents options used to show a health monitor.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -215,13 +223,17 @@ Update Health Monitor Attributes
 type UpdateOpts struct {
 
 	// - Name of the health monitor
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the health monitor
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the health monitor
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -272,7 +284,7 @@ Create Staged Health Monitor Configurations
 type CreateStagedOpts struct {
 
 	// - Port number of the health monitor for healthchecking
-	// - Must be specified `0` when `protocol` is `"icmp"`
+	// - If 'protocol' is 'icmp', value must be set `0`
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -283,20 +295,22 @@ type CreateStagedOpts struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
-	// - Must be specified a number less than or equal to `interval`
+	// - Value must be less than or equal to `interval`
 	Timeout int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Can be specified path to monitor when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, URL path can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, URL path must not be set
 	// - Must be started with /
 	Path string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Can be specified HTTP status code (or range) when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, HTTP status code (or range) can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, HTTP status code (or range) must not be set
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode string `json:"http_status_code,omitempty"`
 }
@@ -348,7 +362,7 @@ Update Staged Health Monitor Configurations
 type UpdateStagedOpts struct {
 
 	// - Port number of the health monitor for healthchecking
-	// - Must be specified `0` when `protocol` is `"icmp"`
+	// - If 'protocol' is 'icmp', value must be set `0`
 	Port *int `json:"port,omitempty"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -359,20 +373,22 @@ type UpdateStagedOpts struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry *int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
-	// - Must be specified a number less than or equal to `interval`
+	// - Value must be less than or equal to `interval`
 	Timeout *int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Can be specified path to monitor when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, URL path can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, URL path must not be set
 	// - Must be started with /
 	Path *string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Can be specified HTTP status code (or range) when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, HTTP status code (or range) can be set
+	//   - If `protocol` is neither `"http"` nor `"https"`, HTTP status code (or range) must not be set
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode *string `json:"http_status_code,omitempty"`
 }

--- a/v3/ecl/managed_load_balancer/v1/health_monitors/results.go
+++ b/v3/ecl/managed_load_balancer/v1/health_monitors/results.go
@@ -64,7 +64,7 @@ type CancelStagedResult struct {
 type ConfigurationInResponse struct {
 
 	// - Port number of the health monitor for healthchecking
-	// - Returns `0` when `protocol` is `"icmp"`
+	// - If `protocol` is `"icmp"`, returns `0`
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -75,18 +75,18 @@ type ConfigurationInResponse struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
 	Timeout int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Used when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, uses this parameter
 	Path string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Used when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, uses this parameter
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode string `json:"http_status_code,omitempty"`
 }
@@ -144,7 +144,7 @@ type HealthMonitor struct {
 	TenantID string `json:"tenant_id"`
 
 	// - Port number of the health monitor for healthchecking
-	// - Returns `0` when `protocol` is `"icmp"`
+	// - If `protocol` is `"icmp"`, returns `0`
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the health monitor for healthchecking
@@ -155,29 +155,29 @@ type HealthMonitor struct {
 
 	// - Retry count of healthchecking
 	// - Initial monitoring is not included
-	// - Retry is executed at the interval specified by `interval`
+	// - Retry is executed at the interval set in `interval`
 	Retry int `json:"retry,omitempty"`
 
 	// - Timeout of healthchecking (in seconds)
 	Timeout int `json:"timeout,omitempty"`
 
 	// - URL path of healthchecking
-	// - Used when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, uses this parameter
 	Path string `json:"path,omitempty"`
 
 	// - HTTP status codes expected in healthchecking
-	// - Used when `protocol` is `"http"` or `"https"`
+	// - If `protocol` is `"http"` or `"https"`, uses this parameter
 	// - Format: `"xxx"` or `"xxx-xxx"` ( `xxx` between [100, 599])
 	HttpStatusCode string `json:"http_status_code,omitempty"`
 
 	// - Running configurations of the health monitor
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the health monitor that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/listeners/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/listeners/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -86,22 +88,27 @@ Create Listener
 type CreateOpts struct {
 
 	// - Name of the listener
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the listener
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the listener
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - IP address of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
-	// - Must be specified the ip address which is not included in subnet of load balancer interfaces that the listener belongs to
+	// - Set an unique combination of IP address and port in all listeners which belong to the same load balancer
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the listener belongs to
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 
 	// - Port number of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
+	// - Combination of IP address and port must be unique for all listeners which belong to the same load balancer
 	Port int `json:"port"`
 
 	// - Protocol of the listener for listening
@@ -144,7 +151,7 @@ Show Listener
 // ShowOpts represents options used to show a listener.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -184,13 +191,17 @@ Update Listener Attribute
 type UpdateOpts struct {
 
 	// - Name of the listener
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the listener
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the listener
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -241,12 +252,13 @@ Create Staged Listener Configurations
 type CreateStagedOpts struct {
 
 	// - IP address of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
-	// - Must be specified the ip address which is not included in subnet of load balancer interfaces that the listener belongs to
+	// - Set an unique combination of IP address and port in all listeners which belong to the same load balancer
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the listener belongs to
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address,omitempty"`
 
 	// - Port number of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
+	// - Combination of IP address and port must be unique for all listeners which belong to the same load balancer
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the listener for listening
@@ -300,12 +312,13 @@ Update Staged Listener Configurations
 type UpdateStagedOpts struct {
 
 	// - IP address of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
-	// - Must be specified the ip address which is not included in subnet of load balancer interfaces that the listener belongs to
+	// - Set an unique combination of IP address and port in all listeners which belong to the same load balancer
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the listener belongs to
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress *string `json:"ip_address,omitempty"`
 
 	// - Port number of the listener for listening
-	// - Must be specified the unique combination of ip address and port in all listeners belongs to the same load balancer
+	// - Combination of IP address and port must be unique for all listeners which belong to the same load balancer
 	Port *int `json:"port,omitempty"`
 
 	// - Protocol of the listener for listening

--- a/v3/ecl/managed_load_balancer/v1/listeners/results.go
+++ b/v3/ecl/managed_load_balancer/v1/listeners/results.go
@@ -135,13 +135,13 @@ type Listener struct {
 	Protocol string `json:"protocol,omitempty"`
 
 	// - Running configurations of the listener
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the listener that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/load_balancers/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/load_balancers/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -93,8 +95,9 @@ type CreateOptsReservedFixedIP struct {
 
 	// - The IP address assign to this interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 }
 
@@ -102,20 +105,19 @@ type CreateOptsReservedFixedIP struct {
 type CreateOptsInterface struct {
 
 	// - ID of the network that this interface belongs to
-	// - Must be specified the unique network ID in `interfaces`
-	// - Must be specified the network that plane is data
-	// - Must not be specified the network that uses ISP shared address (RFC 6598)
+	// - Set a unique network ID in `interfaces`
+	// - Set a network of which plane is data
+	// - Must not set ID of a network that uses ISP shared address (RFC 6598)
 	NetworkID string `json:"network_id"`
 
 	// - Virtual IP address of the interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
-	// - Must not be specified for existing interfaces
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Set a network IP address and broadcast IP address
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	VirtualIPAddress string `json:"virtual_ip_address"`
 
 	// - IP addresses that are pre-reserved for applying configurations of load balancer to be performed without losing redundancy
-	// - Must not be specified for existing interfaces
 	ReservedFixedIPs *[]CreateOptsReservedFixedIP `json:"reserved_fixed_ips"`
 }
 
@@ -130,7 +132,7 @@ type CreateOptsSyslogServer struct {
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the syslog server
-	// - Must be specified same protocol in all syslog servers belongs to the same load balancer
+	// - Set same protocol in all syslog servers which belong to the same load balancer
 	Protocol string `json:"protocol,omitempty"`
 }
 
@@ -138,25 +140,30 @@ type CreateOptsSyslogServer struct {
 type CreateOpts struct {
 
 	// - Name of the load balancer
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the load balancer
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the load balancer
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - ID of the plan
 	PlanID string `json:"plan_id,omitempty"`
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers *[]CreateOptsSyslogServer `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer
@@ -198,7 +205,7 @@ Show Load Balancer
 // ShowOpts represents options used to show a load balancer.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -238,13 +245,17 @@ Update Load Balancer Attributes
 type UpdateOpts struct {
 
 	// - Name of the load balancer
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the load balancer
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the load balancer
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -353,8 +364,9 @@ type CreateStagedOptsReservedFixedIP struct {
 
 	// - The IP address assign to this interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 }
 
@@ -362,20 +374,21 @@ type CreateStagedOptsReservedFixedIP struct {
 type CreateStagedOptsInterface struct {
 
 	// - ID of the network that this interface belongs to
-	// - Must be specified the unique network ID in `interfaces`
-	// - Must be specified the network that plane is data
-	// - Must not be specified the network that uses ISP shared address (RFC 6598)
+	// - Set a unique network ID in `interfaces`
+	// - Set a network of which plane is data
+	// - Must not set ID of a network that uses ISP shared address (RFC 6598)
 	NetworkID string `json:"network_id"`
 
 	// - Virtual IP address of the interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
-	// - Must not be specified for existing interfaces
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - If there are no changes to the `network_id` within the `interfaces[]` , set the current `virtual_ip_address` value
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	VirtualIPAddress string `json:"virtual_ip_address"`
 
 	// - IP addresses that are pre-reserved for applying configurations of load balancer to be performed without losing redundancy
-	// - Must not be specified for existing interfaces
+	// - If there are no changes to the `network_id` within the `interfaces[]` , set the current `reserved_fixed_ips` value
 	ReservedFixedIPs *[]CreateStagedOptsReservedFixedIP `json:"reserved_fixed_ips"`
 }
 
@@ -390,7 +403,7 @@ type CreateStagedOptsSyslogServer struct {
 	Port int `json:"port,omitempty"`
 
 	// - Protocol of the syslog server
-	// - Must be specified same protocol in all syslog servers belongs to the same load balancer
+	// - Set same protocol in all syslog servers which belong to the same load balancer
 	Protocol string `json:"protocol,omitempty"`
 }
 
@@ -398,12 +411,13 @@ type CreateStagedOptsSyslogServer struct {
 type CreateStagedOpts struct {
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers *[]CreateStagedOptsSyslogServer `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer
@@ -460,8 +474,9 @@ type UpdateStagedOptsReservedFixedIP struct {
 
 	// - The IP address assign to this interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress *string `json:"ip_address"`
 }
 
@@ -469,20 +484,21 @@ type UpdateStagedOptsReservedFixedIP struct {
 type UpdateStagedOptsInterface struct {
 
 	// - ID of the network that this interface belongs to
-	// - Must be specified the unique network ID in `interfaces`
-	// - Must be specified the network that plane is data
-	// - Must not be specified the network that uses ISP shared address (RFC 6598)
+	// - Set a unique network ID in `interfaces`
+	// - Set a network of which plane is data
+	// - Must not set ID of a network that uses ISP shared address (RFC 6598)
 	NetworkID *string `json:"network_id"`
 
 	// - Virtual IP address of the interface within subnet
 	// - Do not use this IP address at the interface of other devices, allowed address pairs, etc
-	// - Must be specified the unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
-	// - Must not be specified the network IP address and broadcast IP address
-	// - Must not be specified for existing interfaces
+	// - Set an unique IP address in `virtual_ip_address` and `reserved_fixed_ips`
+	// - Must not set a network IP address and broadcast IP address
+	// - If there are no changes to the `network_id` within the `interfaces[]` , set the current `virtual_ip_address` value
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	VirtualIPAddress *string `json:"virtual_ip_address"`
 
 	// - IP addresses that are pre-reserved for applying configurations of load balancer to be performed without losing redundancy
-	// - Must not be specified for existing interfaces
+	// - If there are no changes to the `network_id` within the `interfaces[]` , set the current `reserved_fixed_ips` value
 	ReservedFixedIPs *[]UpdateStagedOptsReservedFixedIP `json:"reserved_fixed_ips"`
 }
 
@@ -497,7 +513,7 @@ type UpdateStagedOptsSyslogServer struct {
 	Port *int `json:"port,omitempty"`
 
 	// - Protocol of the syslog server
-	// - Must be specified same protocol in all syslog servers belongs to the same load balancer
+	// - Set same protocol in all syslog servers which belong to the same load balancer
 	Protocol *string `json:"protocol,omitempty"`
 }
 
@@ -505,12 +521,13 @@ type UpdateStagedOptsSyslogServer struct {
 type UpdateStagedOpts struct {
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers *[]UpdateStagedOptsSyslogServer `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer

--- a/v3/ecl/managed_load_balancer/v1/load_balancers/results.go
+++ b/v3/ecl/managed_load_balancer/v1/load_balancers/results.go
@@ -78,12 +78,13 @@ type ReservedFixedIPInResponse struct {
 type ConfigurationInResponse struct {
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers []SyslogServerInResponse `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer
@@ -178,7 +179,7 @@ type LoadBalancer struct {
 	SecondaryAvailabilityZone string `json:"secondary_availability_zone,omitempty"`
 
 	// - Primary or secondary availability zone where the load balancer is currently running
-	// - Return `"UNDEFINED"` if can not define active availability zone
+	// - If can not define active availability zone, returns `"UNDEFINED"`
 	ActiveAvailabilityZone string `json:"active_availability_zone"`
 
 	// - Revision of the load balancer
@@ -194,25 +195,26 @@ type LoadBalancer struct {
 	TenantID string `json:"tenant_id"`
 
 	// - Syslog servers to which access logs are transferred
+	// - The facility code of syslog is 0 (kern), and the severity level is 6 (info)
 	// - Only access logs to listeners which `protocol` is either `"http"` or `"https"` are transferred
-	//   - When `protocol` of `syslog_servers` is `"tcp"`
-	//     - Access logs are transferred to all healthy syslog servers specified in `syslog_servers`
-	//   - When `protocol` of `syslog_servers` is `"udp"`
-	//     - Access logs are transferred to the syslog server specified first in `syslog_servers` as long as it is healthy
-	//     - Access logs are transferred to the syslog server specified second (last) in `syslog_servers` when the first syslog server is not healthy
+	//   - If `protocol` of `syslog_servers` is `"tcp"`
+	//     - Access logs are transferred to all healthy syslog servers set in `syslog_servers`
+	//   - If `protocol` of `syslog_servers` is `"udp"`
+	//     - Access logs are transferred to the syslog server set first in `syslog_servers` as long as it is healthy
+	//     - Access logs are transferred to the syslog server set second (last) in `syslog_servers` if the first syslog server is not healthy
 	SyslogServers []SyslogServerInResponse `json:"syslog_servers,omitempty"`
 
 	// - Interfaces that attached to the load balancer
 	Interfaces []InterfaceInResponse `json:"interfaces,omitempty"`
 
 	// - Running configurations of the load balancer
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the load balancer that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/operations/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/operations/requests.go
@@ -38,10 +38,10 @@ type ListOpts struct {
 	// - ID of the owner tenant of the resource
 	TenantID string `q:"tenant_id"`
 
-	// - When `true` is specified, operations of deleted resource is not displayed
+	// - If `true` is set, operations of deleted resource is not displayed
 	NoDeleted bool `q:"no_deleted"`
 
-	// - When `true` is specified, only the latest operation of each resource is displayed
+	// - If `true` is set, only the latest operation of each resource is displayed
 	Latest bool `q:"latest"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/plans/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/plans/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Bandwidth of the plan

--- a/v3/ecl/managed_load_balancer/v1/policies/doc.go
+++ b/v3/ecl/managed_load_balancer/v1/policies/doc.go
@@ -37,6 +37,7 @@ Example to create a policy
 		Tags: tags,
 		Algorithm: "round-robin",
 		Persistence: "cookie",
+		IdleTimeout: 600,
 		SorryPageUrl: "https://example.com/sorry",
 		SourceNat: "enable",
 		CertificateID: "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -105,6 +106,7 @@ Example to create staged policy configurations
 	createStagedOpts := policies.CreateStagedOpts{
 		Algorithm: "round-robin",
 		Persistence: "cookie",
+		IdleTimeout: 600,
 		SorryPageUrl: "https://example.com/sorry",
 		SourceNat: "enable",
 		CertificateID: "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -136,6 +138,7 @@ Example to update staged policy configurations
 
 	algorithm := "round-robin"
 	persistence := "cookie"
+	idleTimeout := 600
 	sorryPageUrl := "https://example.com/sorry"
 	sourceNat := "enable"
 	certificateID := "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -146,6 +149,7 @@ Example to update staged policy configurations
 	updateStagedOpts := policies.UpdateStagedOpts{
 		Algorithm: &algorithm,
 		Persistence: &persistence,
+		IdleTimeout: &idleTimeout,
 		SorryPageUrl: &sorryPageUrl,
 		SourceNat: &sourceNat,
 		CertificateID: &certificateID,

--- a/v3/ecl/managed_load_balancer/v1/policies/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/policies/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -37,8 +39,7 @@ type ListOpts struct {
 	// - Persistence setting of the policy
 	Persistence string `q:"persistence"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Must be specified as URL format
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	SorryPageUrl string `q:"sorry_page_url"`
 
 	// - Source NAT setting of the policy
@@ -105,56 +106,60 @@ Create Policy
 type CreateOpts struct {
 
 	// - Name of the policy
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the policy
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the policy
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - Load balancing algorithm (method) of the policy
 	Algorithm string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Can be specified when `listener.protocol` is `"http"` or `"https"`
-	// - Must be specified as URL format
-	// - Must not be specified or be specified as `""` when `listener.protocol` is neither `"http"` nor `"https"`
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
+	// - If `listener.protocol` is neither `"http"` nor `"https"`, must not set this parameter or set `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"`
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Can be specified the certificate which `ca_cert.status` , `ssl_cert.status` and `ssl_key.status` is `"UPLOADED"`
-	// - Must be specified `certificate.id` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
+	// - You can set a ID of the certificate in which `ca_cert.status`, `ssl_cert.status` and `ssl_key.status` are all `"UPLOADED"`
+	// - If `listener.protocol` is `"https"`, set `certificate.id`
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
 	CertificateID string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
-	// - Must not be specified the ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
 	HealthMonitorID string `json:"health_monitor_id"`
 
 	// - ID of the listener that assigned to the policy
-	// - Must not be specified the ID of the listener that `configuration_status` is `"DELETE_STAGED"`
-	// - Must not be specified the ID of the listener that already assigned to the other policy
+	// - Must not set ID of the listener that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the listener that already assigned to the other policy
 	ListenerID string `json:"listener_id"`
 
 	// - ID of the default target group that assigned to the policy
-	// - Must not be specified the ID of the target group that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the target group that `configuration_status` is `"DELETE_STAGED"`
 	DefaultTargetGroupID string `json:"default_target_group_id"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Can be specified or will be set `tls_policy.id` which `default` is `true` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
+	// - If `listener.protocol` is `"https"`, you can set this parameter explicitly
+	//   - If not set this parameter, the ID of the `tls_policy` with `default: true` will be automatically set
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
 	TLSPolicyID string `json:"tls_policy_id,omitempty"`
 
 	// - ID of the load balancer which the policy belongs to
@@ -194,7 +199,7 @@ Show Policy
 // ShowOpts represents options used to show a policy.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -234,13 +239,17 @@ Update Policy Attributes
 type UpdateOpts struct {
 
 	// - Name of the policy
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the policy
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the policy
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -294,46 +303,46 @@ type CreateStagedOpts struct {
 	Algorithm string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Can be specified when `listener.protocol` is `"http"` or `"https"`
-	// - Must be specified as URL format
-	// - Must not be specified or be specified as `""` when `listener.protocol` is neither `"http"` nor `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"http"` or `"https"` to others
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
+	// - If `listener.protocol` is neither `"http"` nor `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"http"` or `"https"` to others, set `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"`
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Can be specified the certificate which `ca_cert.status` , `ssl_cert.status` and `ssl_key.status` is `"UPLOADED"`
-	// - Must be specified `certificate.id` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"https"` to others
+	// - You can set a ID of the certificate in which `ca_cert.status`, `ssl_cert.status` and `ssl_key.status` are all `"UPLOADED"`
+	// - If `listener.protocol` is `"https"`, set `certificate.id`
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"https"` to others, set `""`
 	CertificateID string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
-	// - Must not be specified the ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
 	HealthMonitorID string `json:"health_monitor_id,omitempty"`
 
 	// - ID of the listener that assigned to the policy
-	// - Must not be specified the ID of the listener that `configuration_status` is `"DELETE_STAGED"`
-	// - Must not be specified the ID of the listener that already assigned to the other policy
+	// - Must not set ID of the listener that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the listener that already assigned to the other policy
 	ListenerID string `json:"listener_id,omitempty"`
 
 	// - ID of the default target group that assigned to the policy
-	// - Must not be specified the ID of the target group that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the target group that `configuration_status` is `"DELETE_STAGED"`
 	DefaultTargetGroupID string `json:"default_target_group_id,omitempty"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Can be specified or will be set `tls_policy.id` which `default` is `true` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"https"` to others
+	// - If `listener.protocol` is `"https"`, you can set this parameter explicitly
+	//   - If not set this parameter, the ID of the `tls_policy` with `default: true` will be automatically set
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"https"` to others, set `""`
 	TLSPolicyID string `json:"tls_policy_id,omitempty"`
 }
 
@@ -387,46 +396,46 @@ type UpdateStagedOpts struct {
 	Algorithm *string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence *string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Can be specified when `listener.protocol` is `"http"` or `"https"`
-	// - Must be specified as URL format
-	// - Must not be specified or be specified as `""` when `listener.protocol` is neither `"http"` nor `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"http"` or `"https"` to others
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
+	// - If `listener.protocol` is neither `"http"` nor `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"http"` or `"https"` to others, set `""`
 	SorryPageUrl *string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"`
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat *string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Can be specified the certificate which `ca_cert.status` , `ssl_cert.status` and `ssl_key.status` is `"UPLOADED"`
-	// - Must be specified `certificate.id` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"https"` to others
+	// - You can set a ID of the certificate in which `ca_cert.status`, `ssl_cert.status` and `ssl_key.status` are all `"UPLOADED"`
+	// - If `listener.protocol` is `"https"`, set `certificate.id`
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"https"` to others, set `""`
 	CertificateID *string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
-	// - Must not be specified the ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the health monitor that `configuration_status` is `"DELETE_STAGED"`
 	HealthMonitorID *string `json:"health_monitor_id,omitempty"`
 
 	// - ID of the listener that assigned to the policy
-	// - Must not be specified the ID of the listener that `configuration_status` is `"DELETE_STAGED"`
-	// - Must not be specified the ID of the listener that already assigned to the other policy
+	// - Must not set ID of the listener that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the listener that already assigned to the other policy
 	ListenerID *string `json:"listener_id,omitempty"`
 
 	// - ID of the default target group that assigned to the policy
-	// - Must not be specified the ID of the target group that `configuration_status` is `"DELETE_STAGED"`
+	// - Must not set ID of the target group that `configuration_status` is `"DELETE_STAGED"`
 	DefaultTargetGroupID *string `json:"default_target_group_id,omitempty"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Can be specified or will be set `tls_policy.id` which `default` is `true` when `listener.protocol` is `"https"`
-	// - Must not be specified or be specified as `""` when `listener.protocol` is not `"https"`
-	//   - Must be specified as `""` when changing `listener.protocol` from `"https"` to others
+	// - If `listener.protocol` is `"https"`, you can set this parameter explicitly
+	//   - If not set this parameter, the ID of the `tls_policy` with `default: true` will be automatically set
+	// - If `listener.protocol` is not `"https"`, must not set this parameter or set `""`
+	//   - If you change `listener.protocol` from `"https"` to others, set `""`
 	TLSPolicyID *string `json:"tls_policy_id,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/policies/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/policies/requests.go
@@ -39,6 +39,9 @@ type ListOpts struct {
 	// - Persistence setting of the policy
 	Persistence string `q:"persistence"`
 
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	IdleTimeout int `q:"idle_timeout"`
+
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	SorryPageUrl string `q:"sorry_page_url"`
 
@@ -125,6 +128,15 @@ type CreateOpts struct {
 	// - Persistence setting of the policy
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
+
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout int `json:"idle_timeout,omitempty"`
 
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
@@ -306,6 +318,15 @@ type CreateStagedOpts struct {
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout int `json:"idle_timeout,omitempty"`
+
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set
 	// - If `listener.protocol` is neither `"http"` nor `"https"`, must not set this parameter or set `""`
@@ -398,6 +419,15 @@ type UpdateStagedOpts struct {
 	// - Persistence setting of the policy
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence *string `json:"persistence,omitempty"`
+
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout *int `json:"idle_timeout,omitempty"`
 
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If `listener.protocol` is `"http"` or `"https"`, this parameter can be set

--- a/v3/ecl/managed_load_balancer/v1/policies/results.go
+++ b/v3/ecl/managed_load_balancer/v1/policies/results.go
@@ -67,21 +67,21 @@ type ConfigurationInResponse struct {
 	Algorithm string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Returns `""` when protocol is not `"http"` or `"https"`
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If protocol is not `"http"` or `"https"`, returns `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Returns `""` when protocol is not `"https"`
+	// - If protocol is not `"https"`, returns `""`
 	CertificateID string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
@@ -94,7 +94,7 @@ type ConfigurationInResponse struct {
 	DefaultTargetGroupID string `json:"default_target_group_id,omitempty"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Returns `""` when protocol is not `"https"`
+	// - If protocol is not `"https"`, returns `""`
 	TLSPolicyID string `json:"tls_policy_id,omitempty"`
 }
 
@@ -154,21 +154,21 @@ type Policy struct {
 	Algorithm string `json:"algorithm,omitempty"`
 
 	// - Persistence setting of the policy
-	// - `"cookie"` is used when `listener.protocol` is `"http"` or `"https"`
+	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
-	// - URL of the sorry page to which accesses are redirected when all members in the target group are down
-	// - Returns `""` when protocol is not `"http"` or `"https"`
+	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
+	// - If protocol is not `"http"` or `"https"`, returns `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
 
 	// - Source NAT setting of the policy
-	// - When `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
+	// - If `source_nat` is `"enable"` and `listener.protocol` is `"http"` or `"https"` ,
 	//   - The source IP address of the request is replaced with `virtual_ip_address` which is assigned to the interface from which the request was sent
 	//   - `X-Forwarded-For` header with the IP address of the client is added
 	SourceNat string `json:"source_nat,omitempty"`
 
 	// - ID of the certificate that assigned to the policy
-	// - Returns `""` when protocol is not `"https"`
+	// - If protocol is not `"https"`, returns `""`
 	CertificateID string `json:"certificate_id,omitempty"`
 
 	// - ID of the health monitor that assigned to the policy
@@ -181,17 +181,17 @@ type Policy struct {
 	DefaultTargetGroupID string `json:"default_target_group_id,omitempty"`
 
 	// - ID of the TLS policy that assigned to the policy
-	// - Returns `""` when protocol is not `"https"`
+	// - If protocol is not `"https"`, returns `""`
 	TLSPolicyID string `json:"tls_policy_id,omitempty"`
 
 	// - Running configurations of the policy
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the policy that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/policies/results.go
+++ b/v3/ecl/managed_load_balancer/v1/policies/results.go
@@ -70,6 +70,15 @@ type ConfigurationInResponse struct {
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
 
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout int `json:"idle_timeout,omitempty"`
+
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If protocol is not `"http"` or `"https"`, returns `""`
 	SorryPageUrl string `json:"sorry_page_url,omitempty"`
@@ -156,6 +165,15 @@ type Policy struct {
 	// - Persistence setting of the policy
 	// - If `listener.protocol` is `"http"` or `"https"`, `"cookie"` is available
 	Persistence string `json:"persistence,omitempty"`
+
+	// - The duration (in seconds) during which a session is allowed to remain inactive
+	// - There may be a time difference up to 60 seconds, between the set value and the actual timeout
+	// - If `listener.protocol` is `"tcp"` or `"udp"`
+	//   - Default value is 120
+	// - If `listener.protocol` is `"http"` or `"https"`
+	//   - Default value is 600
+	//   - On session timeout, the load balancer sends TCP RST packets to both the client and the real server
+	IdleTimeout int `json:"idle_timeout,omitempty"`
 
 	// - URL of the sorry page to which accesses are redirected if all members in the target group are down
 	// - If protocol is not `"http"` or `"https"`, returns `""`

--- a/v3/ecl/managed_load_balancer/v1/policies/testing/fixtures.go
+++ b/v3/ecl/managed_load_balancer/v1/policies/testing/fixtures.go
@@ -28,6 +28,7 @@ var listResponse = fmt.Sprintf(`
             "tenant_id": "34f5c98ef430457ba81292637d0c6fd0",
             "algorithm": "round-robin",
             "persistence": "cookie",
+            "idle_timeout": 600,
             "sorry_page_url": "https://example.com/sorry",
             "source_nat": "enable",
             "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -59,6 +60,7 @@ func listResult() []policies.Policy {
 	policy1.TenantID = "34f5c98ef430457ba81292637d0c6fd0"
 	policy1.Algorithm = "round-robin"
 	policy1.Persistence = "cookie"
+	policy1.IdleTimeout = 600
 	policy1.SorryPageUrl = "https://example.com/sorry"
 	policy1.SourceNat = "enable"
 	policy1.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -80,6 +82,7 @@ var createRequest = fmt.Sprintf(`
         },
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -106,6 +109,7 @@ var createResponse = fmt.Sprintf(`
         "tenant_id": "34f5c98ef430457ba81292637d0c6fd0",
         "algorithm": null,
         "persistence": null,
+        "idle_timeout": null,
         "sorry_page_url": null,
         "source_nat": null,
         "certificate_id": null,
@@ -136,6 +140,7 @@ func createResult() *policies.Policy {
 	policy.TenantID = "34f5c98ef430457ba81292637d0c6fd0"
 	policy.Algorithm = ""
 	policy.Persistence = ""
+	policy.IdleTimeout = 0
 	policy.SorryPageUrl = ""
 	policy.SourceNat = ""
 	policy.CertificateID = ""
@@ -162,6 +167,7 @@ var showResponse = fmt.Sprintf(`
         "tenant_id": "34f5c98ef430457ba81292637d0c6fd0",
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -172,6 +178,7 @@ var showResponse = fmt.Sprintf(`
         "current": {
             "algorithm": "round-robin",
             "persistence": "cookie",
+            "idle_timeout": 600,
             "sorry_page_url": "https://example.com/sorry",
             "source_nat": "enable",
             "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -191,6 +198,7 @@ func showResult() *policies.Policy {
 	current := policies.ConfigurationInResponse{
 		Algorithm:            "round-robin",
 		Persistence:          "cookie",
+		IdleTimeout:          600,
 		SorryPageUrl:         "https://example.com/sorry",
 		SourceNat:            "enable",
 		CertificateID:        "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -217,6 +225,7 @@ func showResult() *policies.Policy {
 	policy.TenantID = "34f5c98ef430457ba81292637d0c6fd0"
 	policy.Algorithm = "round-robin"
 	policy.Persistence = "cookie"
+	policy.IdleTimeout = 600
 	policy.SorryPageUrl = "https://example.com/sorry"
 	policy.SourceNat = "enable"
 	policy.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -256,6 +265,7 @@ var updateResponse = fmt.Sprintf(`
         "tenant_id": "34f5c98ef430457ba81292637d0c6fd0",
         "algorithm": null,
         "persistence": null,
+        "idle_timeout": null,
         "sorry_page_url": null,
         "source_nat": null,
         "certificate_id": null,
@@ -286,6 +296,7 @@ func updateResult() *policies.Policy {
 	policy.TenantID = "34f5c98ef430457ba81292637d0c6fd0"
 	policy.Algorithm = ""
 	policy.Persistence = ""
+	policy.IdleTimeout = 0
 	policy.SorryPageUrl = ""
 	policy.SourceNat = ""
 	policy.CertificateID = ""
@@ -302,6 +313,7 @@ var createStagedRequest = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -317,6 +329,7 @@ var createStagedResponse = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -332,6 +345,7 @@ func createStagedResult() *policies.Policy {
 
 	policy.Algorithm = "round-robin"
 	policy.Persistence = "cookie"
+	policy.IdleTimeout = 600
 	policy.SorryPageUrl = "https://example.com/sorry"
 	policy.SourceNat = "enable"
 	policy.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -348,6 +362,7 @@ var showStagedResponse = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -363,6 +378,7 @@ func showStagedResult() *policies.Policy {
 
 	policy.Algorithm = "round-robin"
 	policy.Persistence = "cookie"
+	policy.IdleTimeout = 600
 	policy.SorryPageUrl = "https://example.com/sorry"
 	policy.SourceNat = "enable"
 	policy.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -379,6 +395,7 @@ var updateStagedRequest = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -394,6 +411,7 @@ var updateStagedResponse = fmt.Sprintf(`
     "policy": {
         "algorithm": "round-robin",
         "persistence": "cookie",
+        "idle_timeout": 600,
         "sorry_page_url": "https://example.com/sorry",
         "source_nat": "enable",
         "certificate_id": "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -409,6 +427,7 @@ func updateStagedResult() *policies.Policy {
 
 	policy.Algorithm = "round-robin"
 	policy.Persistence = "cookie"
+	policy.IdleTimeout = 600
 	policy.SorryPageUrl = "https://example.com/sorry"
 	policy.SourceNat = "enable"
 	policy.CertificateID = "f57a98fe-d63e-4048-93a0-51fe163f30d7"

--- a/v3/ecl/managed_load_balancer/v1/policies/testing/requests_test.go
+++ b/v3/ecl/managed_load_balancer/v1/policies/testing/requests_test.go
@@ -97,6 +97,7 @@ func TestCreatePolicy(t *testing.T) {
 		Tags:                 tags,
 		Algorithm:            "round-robin",
 		Persistence:          "cookie",
+		IdleTimeout:          600,
 		SorryPageUrl:         "https://example.com/sorry",
 		SourceNat:            "enable",
 		CertificateID:        "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -223,6 +224,7 @@ func TestCreateStagedPolicy(t *testing.T) {
 	createStagedOpts := policies.CreateStagedOpts{
 		Algorithm:            "round-robin",
 		Persistence:          "cookie",
+		IdleTimeout:          600,
 		SorryPageUrl:         "https://example.com/sorry",
 		SourceNat:            "enable",
 		CertificateID:        "f57a98fe-d63e-4048-93a0-51fe163f30d7",
@@ -284,6 +286,7 @@ func TestUpdateStagedPolicy(t *testing.T) {
 
 	algorithm := "round-robin"
 	persistence := "cookie"
+	idleTimeout := 600
 	sorryPageUrl := "https://example.com/sorry"
 	sourceNat := "enable"
 	certificateID := "f57a98fe-d63e-4048-93a0-51fe163f30d7"
@@ -294,6 +297,7 @@ func TestUpdateStagedPolicy(t *testing.T) {
 	updateStagedOpts := policies.UpdateStagedOpts{
 		Algorithm:            &algorithm,
 		Persistence:          &persistence,
+		IdleTimeout:          &idleTimeout,
 		SorryPageUrl:         &sorryPageUrl,
 		SourceNat:            &sourceNat,
 		CertificateID:        &certificateID,

--- a/v3/ecl/managed_load_balancer/v1/routes/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/routes/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -83,26 +85,31 @@ Create Route
 type CreateOpts struct {
 
 	// - Name of the (static) route
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the (static) route
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the (static) route
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - CIDR of destination for the (static) route
-	// - Can be specified as `0.0.0.0/0` to configure default gateway
+	// - If you configure `destination_cidr` as default gateway, set `0.0.0.0/0`
 	// - `destination_cidr` can not be changed once configured
-	//   - To change `destination_cidr` , recreating the (static) route is needed
-	// - Must be specified the unique CIDR in all (static) routes belongs to the same load balancer
-	// - Must be specified the CIDR which is not included in subnet of load balancer interfaces that the (static) route belongs to
+	//   - If you want to change `destination_cidr`, recreate the (static) route again
+	// - Set a unique CIDR for all (static) routes which belong to the same load balancer
+	// - Set a CIDR which is not included in subnet of load balancer interfaces that the (static) route belongs to
+	// - Must not set a link-local CIDR (RFC 3927) which includes Common Function Gateway
 	DestinationCidr string `json:"destination_cidr"`
 
 	// - ID of the load balancer which the (static) route belongs to
-	// - Must be specified the CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set a CIDR which is not included in subnet of load balancer interfaces that the (static) route belongs to
+	// - Must not set a network IP address and broadcast IP address
 	NextHopIPAddress string `json:"next_hop_ip_address"`
 
 	// - ID of the load balancer which the (static) route belongs to
@@ -142,7 +149,7 @@ Show Route
 // ShowOpts represents options used to show a route.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -182,13 +189,17 @@ Update Route Attributes
 type UpdateOpts struct {
 
 	// - Name of the (static) route
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the (static) route
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the (static) route
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -239,8 +250,8 @@ Create Staged Route Configurations
 type CreateStagedOpts struct {
 
 	// - ID of the load balancer which the (static) route belongs to
-	// - Must be specified the CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set a CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
+	// - Must not set a network IP address and broadcast IP address
 	NextHopIPAddress string `json:"next_hop_ip_address,omitempty"`
 }
 
@@ -291,8 +302,8 @@ Update Staged Route Configurations
 type UpdateStagedOpts struct {
 
 	// - ID of the load balancer which the (static) route belongs to
-	// - Must be specified the CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
-	// - Must not be specified the network IP address and broadcast IP address
+	// - Set a CIDR which is included in subnet of load balancer interfaces that the (static) route belongs to
+	// - Must not set a network IP address and broadcast IP address
 	NextHopIPAddress *string `json:"next_hop_ip_address,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/routes/results.go
+++ b/v3/ecl/managed_load_balancer/v1/routes/results.go
@@ -126,13 +126,13 @@ type Route struct {
 	NextHopIPAddress string `json:"next_hop_ip_address,omitempty"`
 
 	// - Running configurations of the (static) route
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the (static) route that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/rules/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/rules/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -86,8 +88,8 @@ Create Rule
 type CreateOptsCondition struct {
 
 	// - URL path patterns (regular expressions) of the condition
-	// - Must be specified the unique string in all path patterns belongs to the same policy
-	// - Must be specified as PCRE (Perl Compatible Regular Expressions) format
+	// - Set a path pattern as unique string in all path patterns which belong to the same policy
+	// - Set a path pattern in PCRE (Perl Compatible Regular Expressions) format
 	//   - Capturing groups and backreferences are not supported
 	PathPatterns []string `json:"path_patterns,omitempty"`
 }
@@ -96,29 +98,33 @@ type CreateOptsCondition struct {
 type CreateOpts struct {
 
 	// - Name of the rule
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the rule
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the rule
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - Priority of the rule
-	// - Must be specified the unique number in all rules belongs to the same policy
+	// - Set an unique number in all rules which belong to the same policy
 	Priority int `json:"priority,omitempty"`
 
 	// - ID of the target group that assigned to the rule
-	// - Must be specified the different target group from `"default_target_group_id"` of the policy
+	// - Set a different target group from `"default_target_group_id"` of the policy
 	TargetGroupID string `json:"target_group_id,omitempty"`
 
 	// - ID of the policy which the rule belongs to
-	// - Must be specified a policy which has a listener of which protocol is either `"http"` or `"https"`
+	// - Set ID of the policy which has a listener in which protocol is either `"http"` or `"https"`
 	PolicyID string `json:"policy_id,omitempty"`
 
 	// - Conditions of the rules to distribute accesses to the target groups
-	// - Must be specified one or more condition
+	// - Set one or more condition
 	Conditions *CreateOptsCondition `json:"conditions,omitempty"`
 }
 
@@ -155,7 +161,7 @@ Show Rule
 // ShowOpts represents options used to show a rule.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -195,13 +201,17 @@ Update Rule Attributes
 type UpdateOpts struct {
 
 	// - Name of the rule
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the rule
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the rule
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -252,8 +262,8 @@ Create Staged Rule Configurations
 type CreateStagedOptsCondition struct {
 
 	// - URL path patterns (regular expressions) of the condition
-	// - Must be specified the unique string in all path patterns belongs to the same policy
-	// - Must be specified as PCRE (Perl Compatible Regular Expressions) format
+	// - Set a path pattern as unique string in all path patterns which belong to the same policy
+	// - Set a path pattern in PCRE (Perl Compatible Regular Expressions) format
 	//   - Capturing groups and backreferences are not supported
 	PathPatterns []string `json:"path_patterns,omitempty"`
 }
@@ -262,15 +272,15 @@ type CreateStagedOptsCondition struct {
 type CreateStagedOpts struct {
 
 	// - Priority of the rule
-	// - Must be specified the unique number in all rules belongs to the same policy
+	// - Set an unique number in all rules which belong to the same policy
 	Priority int `json:"priority,omitempty"`
 
 	// - ID of the target group that assigned to the rule
-	// - Must be specified the different target group from `"default_target_group_id"` of the policy
+	// - Set a different target group from `"default_target_group_id"` of the policy
 	TargetGroupID string `json:"target_group_id,omitempty"`
 
 	// - Conditions of the rules to distribute accesses to the target groups
-	// - Must be specified one or more condition
+	// - Set one or more condition
 	Conditions *CreateStagedOptsCondition `json:"conditions,omitempty"`
 }
 
@@ -321,8 +331,8 @@ Update Staged Rule Configurations
 type UpdateStagedOptsCondition struct {
 
 	// - URL path patterns (regular expressions) of the condition
-	// - Must be specified the unique string in all path patterns belongs to the same policy
-	// - Must be specified as PCRE (Perl Compatible Regular Expressions) format
+	// - Set a path pattern as unique string in all path patterns which belong to the same policy
+	// - Set a path pattern in PCRE (Perl Compatible Regular Expressions) format
 	//   - Capturing groups and backreferences are not supported
 	PathPatterns *[]string `json:"path_patterns,omitempty"`
 }
@@ -331,15 +341,15 @@ type UpdateStagedOptsCondition struct {
 type UpdateStagedOpts struct {
 
 	// - Priority of the rule
-	// - Must be specified the unique number in all rules belongs to the same policy
+	// - Set an unique number in all rules which belong to the same policy
 	Priority *int `json:"priority,omitempty"`
 
 	// - ID of the target group that assigned to the rule
-	// - Must be specified the different target group from `"default_target_group_id"` of the policy
+	// - Set a different target group from `"default_target_group_id"` of the policy
 	TargetGroupID *string `json:"target_group_id,omitempty"`
 
 	// - Conditions of the rules to distribute accesses to the target groups
-	// - Must be specified one or more condition
+	// - Set one or more condition
 	Conditions *UpdateStagedOptsCondition `json:"conditions,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/rules/results.go
+++ b/v3/ecl/managed_load_balancer/v1/rules/results.go
@@ -145,13 +145,13 @@ type Rule struct {
 	Conditions ConditionInResponse `json:"conditions,omitempty"`
 
 	// - Running configurations of the rule
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the rule that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/system_updates/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/system_updates/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - URL of announcement for the system update (for example, Knowledge Center news)
@@ -37,7 +39,7 @@ type ListOpts struct {
 	// - Whether the system update can be applied to the load balancer
 	Applicable bool `q:"applicable"`
 
-	// - When `true` is specified, only the latest resource is displayed
+	// - If `true` is set, only the latest resource is displayed
 	Latest bool `q:"latest"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/target_groups/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/target_groups/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Configuration status of the resource
@@ -77,16 +79,19 @@ Create Target Group
 type CreateOptsMember struct {
 
 	// - IP address of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the target group belongs to
+	// - Must not set a IP address of listeners which belong to the same load balancer as the target group
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 
 	// - Port number of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
 	Port int `json:"port"`
 
 	// - Weight for the member (real server)
-	// - Used when `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`
-	// - Must be specified same weight for the combination of ip address and port in all members belongs to the same load balancer
+	// - If `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`, use this parameter
+	// - Set same weight for the combination of IP address and port in all members which belong to the same load balancer
 	Weight int `json:"weight,omitempty"`
 }
 
@@ -94,13 +99,17 @@ type CreateOptsMember struct {
 type CreateOpts struct {
 
 	// - Name of the target group
+	// - This field accepts single-byte characters only
 	Name string `json:"name,omitempty"`
 
 	// - Description of the target group
+	// - This field accepts single-byte characters only
 	Description string `json:"description,omitempty"`
 
 	// - Tags of the target group
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags map[string]interface{} `json:"tags,omitempty"`
 
 	// - ID of the load balancer which the target group belongs to
@@ -143,7 +152,7 @@ Show Target Group
 // ShowOpts represents options used to show a target group.
 type ShowOpts struct {
 
-	// - When `true` is specified, `current` and `staged` are returned in response body
+	// - If `true` is set, `current` and `staged` are returned in response body
 	Changes bool `q:"changes"`
 }
 
@@ -183,13 +192,17 @@ Update Target Group Attributes
 type UpdateOpts struct {
 
 	// - Name of the target group
+	// - This field accepts single-byte characters only
 	Name *string `json:"name,omitempty"`
 
 	// - Description of the target group
+	// - This field accepts single-byte characters only
 	Description *string `json:"description,omitempty"`
 
 	// - Tags of the target group
-	// - Must be specified as JSON object
+	// - Set JSON object up to 32,768 characters
+	//   - Nested structure is permitted
+	// - This field accepts single-byte characters only
 	Tags *map[string]interface{} `json:"tags,omitempty"`
 }
 
@@ -240,16 +253,19 @@ Create Staged Target Group Configurations
 type CreateStagedOptsMember struct {
 
 	// - IP address of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the target group belongs to
+	// - Must not set a IP address of listeners which belong to the same load balancer as the target group
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress string `json:"ip_address"`
 
 	// - Port number of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
 	Port int `json:"port"`
 
 	// - Weight for the member (real server)
-	// - Used when `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`
-	// - Must be specified same weight for the combination of ip address and port in all members belongs to the same load balancer
+	// - If `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`, use this parameter
+	// - Set same weight for the combination of IP address and port in all members which belong to the same load balancer
 	Weight int `json:"weight,omitempty"`
 }
 
@@ -307,16 +323,19 @@ Update Staged Target Group Configurations
 type UpdateStagedOptsMember struct {
 
 	// - IP address of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
+	// - Must not set a IP address which is included in `virtual_ip_address` and `reserved_fixed_ips` of load balancer interfaces that the target group belongs to
+	// - Must not set a IP address of listeners which belong to the same load balancer as the target group
+	// - Must not set a link-local IP address (RFC 3927) which includes Common Function Gateway
 	IPAddress *string `json:"ip_address"`
 
 	// - Port number of the member (real server)
-	// - Must be specified the unique combination of ip address and port in all members belongs to the same target group
+	// - Set an unique combination of IP address and port in all members which belong to the same target group
 	Port *int `json:"port"`
 
 	// - Weight for the member (real server)
-	// - Used when `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`
-	// - Must be specified same weight for the combination of ip address and port in all members belongs to the same load balancer
+	// - If `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`, use this parameter
+	// - Set same weight for the combination of IP address and port in all members which belong to the same load balancer
 	Weight *int `json:"weight,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/target_groups/results.go
+++ b/v3/ecl/managed_load_balancer/v1/target_groups/results.go
@@ -77,7 +77,7 @@ type MemberInResponse struct {
 	Port int `json:"port"`
 
 	// - Weight for the member (real server)
-	// - Used when `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`
+	// - If `policy.algorithm` is `"weighted-round-robin"` or `"weighted-least-connection"`, uses this parameter
 	Weight int `json:"weight"`
 }
 
@@ -137,13 +137,13 @@ type TargetGroup struct {
 	Members []MemberInResponse `json:"members,omitempty"`
 
 	// - Running configurations of the target group
-	// - Return object when `changes` is `true`
-	// - Return `null` when current configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If current configuration does not exist, return `null`
 	Current ConfigurationInResponse `json:"current,omitempty"`
 
 	// - Added or changed configurations of the target group that waiting to be applied
-	// - Return object when `changes` is `true`
-	// - Return `null` when staged configuration does not exist
+	// - If `changes` is `true`, return object
+	// - If staged configuration does not exist, return `null`
 	Staged ConfigurationInResponse `json:"staged,omitempty"`
 }
 

--- a/v3/ecl/managed_load_balancer/v1/tls_policies/requests.go
+++ b/v3/ecl/managed_load_balancer/v1/tls_policies/requests.go
@@ -20,9 +20,11 @@ type ListOpts struct {
 	ID string `q:"id"`
 
 	// - Name of the resource
+	// - This field accepts single-byte characters only
 	Name string `q:"name"`
 
 	// - Description of the resource
+	// - This field accepts single-byte characters only
 	Description string `q:"description"`
 
 	// - Whether the TLS policy will be set `policy.tls_policy_id` when that is not specified


### PR DESCRIPTION
This pull request supports [Managed Load Balancer Day 3](https://sdpf.ntt.com/news/2023101801/) .

- https://github.com/nttcom/eclcloud/commit/3816098775bf83e00dc4f6a842e11be892c7ee14 : Update comments according to [API reference](https://sdpf.ntt.com/services/docs/managed-lb/api-references/managed_load_balancer.html)
- https://github.com/nttcom/eclcloud/commit/c643388545011151719ac37577ede8c00f060f48 : Add idle_timeout to Policy

### Reference

https://github.com/nttcom/terraform-provider-ecl/pull/120