### PR TITLE
feat: VNF-3111 add initial_config to create_vna

### DIFF
--- a/v3/ecl/vna/v1/appliances/requests.go
+++ b/v3/ecl/vna/v1/appliances/requests.go
@@ -94,16 +94,22 @@ type CreateOptsInterfaces struct {
 	Interface8 *CreateOptsInterface `json:"interface_8,omitempty"`
 }
 
+type CreateOptsInitialConfig struct {
+	Format string `json:"format" required:"true"`
+	Data   string `json:"data" required:"true"`
+}
+
 // CreateOpts represents options used to create a virtual network appliance.
 type CreateOpts struct {
-	Name                          string                `json:"name,omitempty"`
-	Description                   string                `json:"description,omitempty"`
-	DefaultGateway                string                `json:"default_gateway,omitempty"`
-	AvailabilityZone              string                `json:"availability_zone,omitempty"`
-	VirtualNetworkAppliancePlanID string                `json:"virtual_network_appliance_plan_id" required:"true"`
-	TenantID                      string                `json:"tenant_id,omitempty"`
-	Tags                          map[string]string     `json:"tags,omitempty"`
-	Interfaces                    *CreateOptsInterfaces `json:"interfaces,omitempty"`
+	Name                          string                   `json:"name,omitempty"`
+	Description                   string                   `json:"description,omitempty"`
+	DefaultGateway                string                   `json:"default_gateway,omitempty"`
+	AvailabilityZone              string                   `json:"availability_zone,omitempty"`
+	VirtualNetworkAppliancePlanID string                   `json:"virtual_network_appliance_plan_id" required:"true"`
+	TenantID                      string                   `json:"tenant_id,omitempty"`
+	Tags                          map[string]string        `json:"tags,omitempty"`
+	Interfaces                    *CreateOptsInterfaces    `json:"interfaces,omitempty"`
+	InitialConfig                 *CreateOptsInitialConfig `json:"initial_config,omitempty"`
 }
 
 // ToApplianceCreateMap builds a request body from CreateOpts.

--- a/v3/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/v3/ecl/vna/v1/appliances/testing/fixtures.go
@@ -514,6 +514,10 @@ var createRequest = fmt.Sprintf(`
     				"network_id": "dummyNetworkID"
     			}
     		},
+            "initial_config": {
+                "format": "set",
+                "data": "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
+            },
     		"tags": {
     			"k1": "v1"
     		},

--- a/v3/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/v3/ecl/vna/v1/appliances/testing/fixtures.go
@@ -514,10 +514,10 @@ var createRequest = fmt.Sprintf(`
     				"network_id": "dummyNetworkID"
     			}
     		},
-            "initial_config": {
-                "format": "set",
-                "data": "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
-            },
+    		"initial_config": {
+    			"format": "set",
+    			"data": "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
+    		},
     		"tags": {
     			"k1": "v1"
     		},

--- a/v3/ecl/vna/v1/appliances/testing/requests_test.go
+++ b/v3/ecl/vna/v1/appliances/testing/requests_test.go
@@ -118,6 +118,10 @@ func TestCreateAppliance(t *testing.T) {
 				},
 			},
 		},
+		InitialConfig: &appliances.CreateOptsInitialConfig{
+			Format: "set",
+			Data:   "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl",
+		},
 	}
 	ap, err := appliances.Create(ServiceClient(), createOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/v4/ecl/vna/v1/appliances/requests.go
+++ b/v4/ecl/vna/v1/appliances/requests.go
@@ -94,16 +94,22 @@ type CreateOptsInterfaces struct {
 	Interface8 *CreateOptsInterface `json:"interface_8,omitempty"`
 }
 
+type CreateOptsInitialConfig struct {
+	Format string `json:"format" required:"true"`
+	Data   string `json:"data" required:"true"`
+}
+
 // CreateOpts represents options used to create a virtual network appliance.
 type CreateOpts struct {
-	Name                          string                `json:"name,omitempty"`
-	Description                   string                `json:"description,omitempty"`
-	DefaultGateway                string                `json:"default_gateway,omitempty"`
-	AvailabilityZone              string                `json:"availability_zone,omitempty"`
-	VirtualNetworkAppliancePlanID string                `json:"virtual_network_appliance_plan_id" required:"true"`
-	TenantID                      string                `json:"tenant_id,omitempty"`
-	Tags                          map[string]string     `json:"tags,omitempty"`
-	Interfaces                    *CreateOptsInterfaces `json:"interfaces,omitempty"`
+	Name                          string                   `json:"name,omitempty"`
+	Description                   string                   `json:"description,omitempty"`
+	DefaultGateway                string                   `json:"default_gateway,omitempty"`
+	AvailabilityZone              string                   `json:"availability_zone,omitempty"`
+	VirtualNetworkAppliancePlanID string                   `json:"virtual_network_appliance_plan_id" required:"true"`
+	TenantID                      string                   `json:"tenant_id,omitempty"`
+	Tags                          map[string]string        `json:"tags,omitempty"`
+	Interfaces                    *CreateOptsInterfaces    `json:"interfaces,omitempty"`
+	InitialConfig                 *CreateOptsInitialConfig `json:"initial_config,omitempty"`
 }
 
 // ToApplianceCreateMap builds a request body from CreateOpts.

--- a/v4/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/v4/ecl/vna/v1/appliances/testing/fixtures.go
@@ -514,6 +514,10 @@ var createRequest = fmt.Sprintf(`
     				"network_id": "dummyNetworkID"
     			}
     		},
+            "initial_config": {
+                "format": "set",
+                "data": "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
+            },
     		"tags": {
     			"k1": "v1"
     		},

--- a/v4/ecl/vna/v1/appliances/testing/fixtures.go
+++ b/v4/ecl/vna/v1/appliances/testing/fixtures.go
@@ -514,10 +514,10 @@ var createRequest = fmt.Sprintf(`
     				"network_id": "dummyNetworkID"
     			}
     		},
-            "initial_config": {
-                "format": "set",
-                "data": "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
-            },
+    		"initial_config": {
+    			"format": "set",
+    			"data": "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
+    		},
     		"tags": {
     			"k1": "v1"
     		},

--- a/v4/ecl/vna/v1/appliances/testing/requests_test.go
+++ b/v4/ecl/vna/v1/appliances/testing/requests_test.go
@@ -118,6 +118,10 @@ func TestCreateAppliance(t *testing.T) {
 				},
 			},
 		},
+		InitialConfig: &appliances.CreateOptsInitialConfig{
+			Format: "set",
+			Data:   "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl",
+		},
 	}
 	ap, err := appliances.Create(ServiceClient(), createOpts).Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
## [VNA] add initial_config to create_vna
### Test
```
➜  v3 git:(john/VNF-3111_initial_config) go test -v ./... -count=1 | grep -v "no test files"
...
PASS
ok      github.com/nttcom/eclcloud/v3/testing   7.164s
terraform test
---
➜  v4 git:(john/VNF-3111_initial_config) ✗ go test -v ./... -count=1 | grep -v "no test files"
…
PASS
ok      github.com/nttcom/eclcloud/v4/testing   7.331s
```